### PR TITLE
fix #51: remove render_form from dashboard app

### DIFF
--- a/dashboard/templates/dashboard/home.html
+++ b/dashboard/templates/dashboard/home.html
@@ -48,7 +48,7 @@
         {% endif %}
         <form action="{% url 'domainauthorization-list' %}" method="POST">
             {% csrf_token %}
-            {% render_form domainauth_serializer %}
+            {{ domain_auth_form }}
             <input type="submit" class="button" value="Add Domain">
         </form>
 
@@ -75,7 +75,7 @@
         {% endif %}
         <form action="{% url 'pushapplication-list' %}" method="POST">
             {% csrf_token %}
-            {% render_form pushapp_serializer %}
+            {{ push_app_form }}
             <input type="submit" class="button" value="Add Push Application">
         </form>
 

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -1,8 +1,8 @@
 from django.views.generic import TemplateView
 
-from api.serializers import (DomainAuthorizationSerializer,
-                             PushApplicationSerializer)
+from domains.forms import DomainAuthForm
 from domains.models import DomainAuthorization
+from push.forms import PushAppForm
 from push.models import PushApplication
 
 
@@ -11,8 +11,8 @@ class Home(TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super(Home, self).get_context_data(**kwargs)
-        context['domainauth_serializer'] = DomainAuthorizationSerializer()
-        context['pushapp_serializer'] = PushApplicationSerializer()
+        context['domain_auth_form'] = DomainAuthForm()
+        context['push_app_form'] = PushAppForm()
         domains = None
         push_apps = None
         if (self.request.user.is_authenticated()):

--- a/domains/forms.py
+++ b/domains/forms.py
@@ -1,0 +1,9 @@
+from django.forms import ModelForm
+
+from .models import DomainAuthorization
+
+
+class DomainAuthForm(ModelForm):
+    class Meta:
+        model = DomainAuthorization
+        fields = ['domain', ]

--- a/push/forms.py
+++ b/push/forms.py
@@ -1,0 +1,9 @@
+from django.forms import ModelForm
+
+from .models import PushApplication
+
+
+class PushAppForm(ModelForm):
+    class Meta:
+        model = PushApplication
+        fields = ['name', 'jws_key']


### PR DESCRIPTION
Instead of using DRF render_form from the api app, use django forms from the
respective apps to render forms for the models.
