### PR TITLE
Correct spacing of Firefox icon in header button

### DIFF
--- a/dashboard/static/css/navigation.css
+++ b/dashboard/static/css/navigation.css
@@ -11,3 +11,8 @@ nav#main-navigation {
 nav#account-management {
     float: right;
 }
+
+nav#account-management .fa-firefox {
+    margin-right: 0;
+    vertical-align: baseline;
+}


### PR DESCRIPTION
Foundation sets a margin-right and vertical-align on <i> elements in
menus, which was moving the Firefox icon out of place.
