### PR TITLE
add fxa dev environment tooltip when DEBUG

### DIFF
--- a/dashboard/settings.py
+++ b/dashboard/settings.py
@@ -57,6 +57,11 @@ INSTALLED_APPS = [
     'push'
 ]
 
+if DEBUG:
+    INSTALLED_APPS += [
+        'debug_toolbar'
+    ]
+
 MIDDLEWARE_CLASSES = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/dashboard/static/css/login.css
+++ b/dashboard/static/css/login.css
@@ -1,0 +1,12 @@
+.sign-in-tooltip {
+    transition: transform 300ms, opacity 300ms;
+    transform: translateY(-1em);
+    opacity: 0;
+    pointer-events: none;
+    position: absolute;
+    display: inline-block;
+}
+.sign-in-area:hover .sign-in-tooltip {
+    transform: translateY(0);
+    opacity: 1;
+}

--- a/dashboard/templates/dashboard/base.html
+++ b/dashboard/templates/dashboard/base.html
@@ -44,7 +44,7 @@
                                 <li><a href="{% url 'account_logout' %}">Sign out</a></li>
                             {% else %}
                                 <li>
-                                    <a class="button" href="{% provider_login_url "fxa" %}?next={{ request.path }}">Sign in with <i class="fa fa-firefox"></i> Firefox Account</a>
+                                {% include "includes/fxa_sign_in_link.html" %}
                                 </li>
                             {% endif %}
                         </ul>

--- a/dashboard/templates/dashboard/home.html
+++ b/dashboard/templates/dashboard/home.html
@@ -9,7 +9,7 @@
         <p>Firefox Developer Services Dashboard shows how your apps and sites
         are using Mozilla services.</p>
         {% if not request.user.is_authenticated %}
-            <a class="button" href="{% provider_login_url "fxa" %}">Sign in with <i class="fa fa-firefox"></i> Firefox Account</a>
+            {% include "includes/fxa_sign_in_link.html" %}
         {% else %}
             <a class="button" href="{% url 'push.applications' %}">Manage your applications</a>
         {% endif %}

--- a/dashboard/templates/dashboard/login.html
+++ b/dashboard/templates/dashboard/login.html
@@ -3,9 +3,9 @@
 
 {% block content %}
     <div id="sign-in-notice">
-        <p class="alert callout">
-            To sign in to this dashboard you must create and verify a Firefox Account on the <a href="https://stable.dev.lcip.org/" target="_blank">Firefox Accounts stable development server</a>.
+        <p class="warning callout">
+            You must sign in to access that page.
         </p>
-        <a class="large button expand" href="{% provider_login_url "fxa" %}">Sign in with <i class="fa fa-firefox"></i> Firefox Account</a>
+        {% include "includes/fxa_sign_in_link.html" %}
     </div>
 {% endblock %}

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -28,7 +28,7 @@ Install Locally
 
 #. `Install requirements`_::
 
-    pip install -r requirements.txt
+    pip install -r requirements-dev.txt
 
 #. Source the ``.env`` file to set environment config vars (Can also use `autoenv`_)::
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+
+django-debug-toolbar==1.4

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
+-r requirements-dev.txt
 
 model-mommy==1.2.6
 fudge==1.1.0

--- a/templates/includes/fxa_sign_in_link.html
+++ b/templates/includes/fxa_sign_in_link.html
@@ -1,0 +1,7 @@
+{% load socialaccount %}
+<div class="sign-in-area">
+    <a class="button sign-in-btn" href="{% provider_login_url "fxa" %}?next={{ request.path }}">Sign in with <i class="fa fa-firefox"></i> Firefox Account</a>
+    {% if debug %}
+    <div class="callout warning sign-in-tooltip">Note: Using dev FxA Environment</div>
+    {% endif %}
+</div>


### PR DESCRIPTION
To spot-check, with `DEBUG=True` hover over a "Sign in with Firefox Accounts" button and you should see a tooltip warning that it uses the dev FxA environment.

In `.env` file, change `DJANGO_DEBUG=False`, run `python manage.py collectstatic --noinput`, and then hover over a sign in button again - no tooltip should show.
