### PR TITLE
Accept the signed token with a text input

### DIFF
--- a/push/forms.py
+++ b/push/forms.py
@@ -1,4 +1,4 @@
-from django.forms import ModelForm, Form, CharField, Textarea
+from django.forms import ModelForm, Form, CharField
 
 from .models import PushApplication
 
@@ -10,4 +10,4 @@ class PushAppForm(ModelForm):
 
 
 class VapidValidationForm(Form):
-    signed_token = CharField(widget=Textarea)
+    signed_token = CharField()


### PR DESCRIPTION
I originally pictured the signed token as being about the length of a
PGP signature. Since it's much shorter than that, we really don't need
the big textarea.
