### PR TITLE
for #99: start l10n messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dashboard/static/lib
 node_modules
 MANIFEST
 .coveralls.yml
+locale/**/*.mo

--- a/dashboard/settings.py
+++ b/dashboard/settings.py
@@ -13,6 +13,7 @@ https://docs.djangoproject.com/en/1.9/ref/settings/
 import os
 
 from decouple import config
+
 import dj_database_url
 
 
@@ -70,6 +71,7 @@ if DEBUG:
 MIDDLEWARE_CLASSES = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -119,6 +121,9 @@ DATABASES['default']['CONN_MAX_AGE'] = 500
 # https://docs.djangoproject.com/en/1.9/topics/i18n/
 
 LANGUAGE_CODE = 'en-us'
+LOCALE_PATHS = [
+    path('locale',),
+]
 
 TIME_ZONE = 'UTC'
 

--- a/dashboard/templates/dashboard/base.html
+++ b/dashboard/templates/dashboard/base.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 {% load pipeline %}
 {% load socialaccount %}
 {% load staticfiles %}
@@ -20,7 +21,7 @@
         <div class="top-bar">
             <div class="row">
                 <div class="top-bar-title">
-                    <a href="/">Firefox Developer Services Dashboard</a>
+                    <a href="/">{% trans "Firefox Developer Services Dashboard" %}</a>
                 </div>
                 <div class="top-bar-right">
                     <nav id="main-navigation">
@@ -29,7 +30,7 @@
                                 <a href="{% url 'push.landing' %}">Push</a>
                                 {% if request.user.is_authenticated %}
                                     <ul class="menu">
-                                        <li><a href="{% url 'push.list' %}">Manage applications</a></li>
+                                        <li><a href="{% url 'push.list' %}">{% trans "Manage applications" %}</a></li>
                                     </ul>
                                 {% endif %}
                             </li>
@@ -54,7 +55,7 @@
             </div>
         </div>
         <main class="row">
-            <nav aria-label="You are here:">
+        <nav aria-label="{% trans "You are here:" %}">
                 <ul class="breadcrumbs">
                     {% block breadcrumbs %}{% endblock %}
                 </ul>
@@ -75,7 +76,7 @@
         <footer>
             <div class="row">
                 <div class="top-bar-right">
-                    <a href="https://github.com/mozilla-services/push-dev-dashboard" target="_blank">Source on GitHub</a> | <a href="https://github.com/mozilla-services/push-dev-dashboard/issues" target="_blank">Issues</a>
+                    <a href="https://github.com/mozilla-services/push-dev-dashboard" target="_blank">{% trans "Source on GitHub" %}</a> | <a href="https://github.com/mozilla-services/push-dev-dashboard/issues" target="_blank">{% trans "Issues" %}</a>
                 </div>
             </div>
         </footer>

--- a/dashboard/templates/dashboard/errors/403.html
+++ b/dashboard/templates/dashboard/errors/403.html
@@ -1,5 +1,6 @@
 {% extends "dashboard/base.html" %}
+{% load i18n %}
 
 {% block content %}
-    <h2>403 Permission Denied</h2>
+<h2>{% trans "403 Permission Denied" %}</h2>
 {% endblock %}

--- a/dashboard/templates/dashboard/errors/404.html
+++ b/dashboard/templates/dashboard/errors/404.html
@@ -1,5 +1,6 @@
 {% extends "dashboard/base.html" %}
+{% load i18n %}
 
 {% block content %}
-    <h2>404 Not Found</h2>
+<h2>{% trans "404 Not Found" %}</h2>
 {% endblock %}

--- a/dashboard/templates/dashboard/errors/500.html
+++ b/dashboard/templates/dashboard/errors/500.html
@@ -1,5 +1,6 @@
 {% extends "dashboard/base.html" %}
+{% load i18n %}
 
 {% block content %}
-    <h2>500 Internal Server Error</h2>
+<h2>{% trans "500 Internal Server Error" %}</h2>
 {% endblock %}

--- a/dashboard/templates/dashboard/home.html
+++ b/dashboard/templates/dashboard/home.html
@@ -1,21 +1,21 @@
 {% extends "dashboard/base.html" %}
+{% load i18n %}
 {% load socialaccount %}
 {% load staticfiles %}
 
 {% block content %}
 <div class="row">
     <div class="large-6 columns">
-        <h2>Monitor your apps in Firefox</h2>
-        <p>Firefox Developer Services Dashboard shows how your apps and sites
-        are using Mozilla services.</p>
+        <h2>{% trans "Monitor your apps in Firefox" %}</h2>
+        <p>{% trans "Firefox Developer Services Dashboard shows how your apps and sites are using Mozilla services." %}</p>
         {% if not request.user.is_authenticated %}
             {% include "includes/fxa_sign_in_link.html" %}
         {% else %}
-            <a class="button" href="{% url 'push.list' %}">Manage your applications</a>
+        <a class="button" href="{% url 'push.list' %}">{% trans "Manage your applications" %}</a>
         {% endif %}
     </div>
     <div class="large-6 columns">
-        <img src="{% static "img/screenshot.png"%}" alt="A screenshot of the codesy.io push application landing page, showing messages and application metadata" />
+        <img src="{% static "img/screenshot.png"%}" alt="{% trans "A screenshot of a push application landing page, showing messages and application metadata" %}" />
     </div>
 </div>
 {% endblock %}

--- a/dashboard/templates/dashboard/login.html
+++ b/dashboard/templates/dashboard/login.html
@@ -1,10 +1,11 @@
 {% extends "dashboard/base.html" %}
+{% load i18n %}
 {% load socialaccount %}
 
 {% block content %}
     <div id="sign-in-notice">
         <p class="warning callout">
-            You must sign in to access that page.
+        {% trans "You must sign in to access that page." %}
         </p>
         {% include "includes/fxa_sign_in_link.html" %}
     </div>

--- a/dashboard/urls.py
+++ b/dashboard/urls.py
@@ -13,8 +13,8 @@ Including another URLconf
     1. Import the include() function: from django.conf.urls import url, include
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
-from django.conf import settings
 from django.conf.urls import url, include
+from django.conf.urls.i18n import i18n_patterns
 from django.contrib import admin
 
 import dashboard.views as dashboard_views
@@ -24,23 +24,18 @@ handler404 = dashboard_views.NotFound.as_view()
 handler500 = dashboard_views.InternalServerError.as_view()
 
 urlpatterns = [
-    # our app urls
-    url(r'^$', dashboard_views.Home.as_view(), name='home'),
-    url(r'^api/docs/', include('rest_framework_swagger.urls')),
-    url(r'^api/v1/', include('api.urls')),
-    url(r'^push/', include('push.urls')),
-    url(r'^accounts/login/$', dashboard_views.Login.as_view(), name='login'),
-
     # 3rd-party app urls
     url(r'^accounts/', include('allauth.urls')),
+    url(r'^api/docs/', include('rest_framework_swagger.urls')),
 
     # django urls
     url(r'^admin/', admin.site.urls),
 ]
 
-# Make some error pages available under error/ for easier testing
-if settings.DEBUG:
-    urlpatterns += [
-        url(r'^error/404/$', dashboard_views.NotFound.as_view()),
-        url(r'^error/500/$', dashboard_views.InternalServerError.as_view()),
-    ]
+urlpatterns += i18n_patterns(
+    # our app urls
+    url(r'^$', dashboard_views.Home.as_view(), name='home'),
+    url(r'^api/v1/', include('api.urls')),
+    url(r'^push/', include('push.urls')),
+    url(r'^accounts/login/$', dashboard_views.Login.as_view(), name='login'),
+)

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -120,6 +120,22 @@ Read the beautiful docs::
     open html/index.html
 
 
+Adding a Translation
+--------------------
+#. Make the ``{locale}`` directory for the new locale::
+
+    mkdir locale/{locale}
+
+#. Run ``makemessages`` to make a ``django.po`` file for it::
+
+    python manage.py makemessages {locale}
+
+#. Add the new directory to git::
+
+    git add locale/{locale}
+    git commit -m "Adding {locale} locale"
+
+
 What to work on
 ---------------
 

--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -1,0 +1,227 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-03-15 22:40+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: dashboard/templates/dashboard/base.html:24
+msgid "Firefox Developer Services Dashboard"
+msgstr ""
+
+#: dashboard/templates/dashboard/base.html:33
+msgid "Manage applications"
+msgstr ""
+
+#: dashboard/templates/dashboard/base.html:58
+msgid "You are here:"
+msgstr ""
+
+#: dashboard/templates/dashboard/base.html:79
+msgid "Source on GitHub"
+msgstr ""
+
+#: dashboard/templates/dashboard/base.html:79
+msgid "Issues"
+msgstr ""
+
+#: dashboard/templates/dashboard/errors/403.html:5
+msgid "403 Permission Denied"
+msgstr ""
+
+#: dashboard/templates/dashboard/errors/404.html:5
+msgid "404 Not Found"
+msgstr ""
+
+#: dashboard/templates/dashboard/errors/500.html:5
+msgid "500 Internal Server Error"
+msgstr ""
+
+#: dashboard/templates/dashboard/home.html:9
+msgid "Monitor your apps in Firefox"
+msgstr ""
+
+#: dashboard/templates/dashboard/home.html:10
+msgid ""
+"Firefox Developer Services Dashboard shows how your apps and sites are using "
+"Mozilla services."
+msgstr ""
+
+#: dashboard/templates/dashboard/home.html:14
+msgid "Manage your applications"
+msgstr ""
+
+#: dashboard/templates/dashboard/home.html:18
+msgid ""
+"A screenshot of a push application landing page, showing messages and "
+"application metadata"
+msgstr ""
+
+#: dashboard/templates/dashboard/login.html:8
+msgid "You must sign in to access that page."
+msgstr ""
+
+#: push/models.py:29
+#, python-format
+msgid "Error communicating with Push Messages API: %s"
+msgstr ""
+
+#: push/models.py:59
+msgid "Unknown public key format specified"
+msgstr ""
+
+#: push/models.py:66
+msgid "Must set PUSH_MESSAGES_API_ENDPOINT env var."
+msgstr ""
+
+#. Translators: Error status code & content returned from an API
+#: push/models.py:84
+#, python-format
+msgid "Status: %(status)s; Content: %(content)s"
+msgstr ""
+
+#: push/models.py:94
+msgid "VAPID p256ecdsa value; url-safe base-64 encoded."
+msgstr ""
+
+#: push/templates/push/details.html:5 push/templates/push/landing.html.py:6
+#: push/templates/push/list.html:6 push/templates/push/validation.html.py:5
+msgid "Home"
+msgstr ""
+
+#: push/templates/push/details.html:7 push/templates/push/list.html.py:8
+#: push/templates/push/validation.html:7
+msgid "Applications"
+msgstr ""
+
+#: push/templates/push/details.html:8 push/templates/push/landing.html.py:7
+#: push/templates/push/list.html:8 push/templates/push/validation.html.py:9
+msgid "Current:"
+msgstr ""
+
+#: push/templates/push/details.html:14 push/templates/push/list.html.py:63
+msgid "Key"
+msgstr ""
+
+#: push/templates/push/details.html:16 push/templates/push/list.html.py:64
+msgid "Key Status"
+msgstr ""
+
+#: push/templates/push/details.html:20 push/templates/push/list.html.py:81
+#: push/templates/push/validation.html:9
+msgid "Validate"
+msgstr ""
+
+#: push/templates/push/details.html:25
+msgid "Messages"
+msgstr ""
+
+#: push/templates/push/details.html:29
+msgid "ID"
+msgstr ""
+
+#: push/templates/push/details.html:30
+msgid "Timestamp"
+msgstr ""
+
+#: push/templates/push/details.html:31
+msgid "Size"
+msgstr ""
+
+#: push/templates/push/details.html:32
+msgid "TTL"
+msgstr ""
+
+#: push/templates/push/details.html:44
+msgid "No messages to display"
+msgstr ""
+
+#: push/templates/push/landing.html:14
+msgid "Manage push applications"
+msgstr ""
+
+#: push/templates/push/landing.html:16
+msgid "Sign in"
+msgstr ""
+
+#: push/templates/push/landing.html:16
+msgid "to track your push applications"
+msgstr ""
+
+#: push/templates/push/list.html:57
+msgid "Push Service Applications"
+msgstr ""
+
+#: push/templates/push/list.html:62
+msgid "Application Name"
+msgstr ""
+
+#: push/templates/push/list.html:88
+msgid "No push applications found."
+msgstr ""
+
+#: push/templates/push/list.html:93
+msgid "Application name:"
+msgstr ""
+
+#: push/templates/push/list.html:96
+msgid "key"
+msgstr ""
+
+#: push/templates/push/list.html:97
+msgid ""
+"The public key that the application server sends for VAPID JWT validation. "
+"This should be the exact value sent in the \\"
+msgstr ""
+
+#: push/templates/push/list.html:100
+msgid "Add Push Application"
+msgstr ""
+
+#: push/templates/push/validation.html:14
+msgid ""
+"To verify you own the signing key for your app, please sign the following "
+"token using the same key you use to sign this application's VAPID JWT, and "
+"paste the url-safe, base64-encoded value below."
+msgstr ""
+
+#: push/templates/push/validation.html:16
+msgid "Token:"
+msgstr ""
+
+#: push/templates/push/validation.html:23
+msgid "URL-safe, base64-encoded signed token:"
+msgstr ""
+
+#: push/templates/push/validation.html:29
+msgid "This application has already been validated."
+msgstr ""
+
+#: push/views.py:82
+msgid "VAPID Key validated."
+msgstr ""
+
+#: push/views.py:84
+msgid "Invalid signature."
+msgstr ""
+
+#: templates/includes/fxa_sign_in_link.html:4
+msgid "Sign in with <i class=\"fa fa-firefox\"></i> Firefox Account "
+msgstr ""
+
+#: templates/includes/fxa_sign_in_link.html:6
+msgid "Note: Using dev FxA Environment"
+msgstr ""

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -1,0 +1,227 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-03-15 22:40+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: dashboard/templates/dashboard/base.html:24
+msgid "Firefox Developer Services Dashboard"
+msgstr ""
+
+#: dashboard/templates/dashboard/base.html:33
+msgid "Manage applications"
+msgstr ""
+
+#: dashboard/templates/dashboard/base.html:58
+msgid "You are here:"
+msgstr ""
+
+#: dashboard/templates/dashboard/base.html:79
+msgid "Source on GitHub"
+msgstr ""
+
+#: dashboard/templates/dashboard/base.html:79
+msgid "Issues"
+msgstr ""
+
+#: dashboard/templates/dashboard/errors/403.html:5
+msgid "403 Permission Denied"
+msgstr ""
+
+#: dashboard/templates/dashboard/errors/404.html:5
+msgid "404 Not Found"
+msgstr ""
+
+#: dashboard/templates/dashboard/errors/500.html:5
+msgid "500 Internal Server Error"
+msgstr ""
+
+#: dashboard/templates/dashboard/home.html:9
+msgid "Monitor your apps in Firefox"
+msgstr ""
+
+#: dashboard/templates/dashboard/home.html:10
+msgid ""
+"Firefox Developer Services Dashboard shows how your apps and sites are using "
+"Mozilla services."
+msgstr ""
+
+#: dashboard/templates/dashboard/home.html:14
+msgid "Manage your applications"
+msgstr ""
+
+#: dashboard/templates/dashboard/home.html:18
+msgid ""
+"A screenshot of a push application landing page, showing messages and "
+"application metadata"
+msgstr ""
+
+#: dashboard/templates/dashboard/login.html:8
+msgid "You must sign in to access that page."
+msgstr ""
+
+#: push/models.py:29
+#, python-format
+msgid "Error communicating with Push Messages API: %s"
+msgstr ""
+
+#: push/models.py:59
+msgid "Unknown public key format specified"
+msgstr ""
+
+#: push/models.py:66
+msgid "Must set PUSH_MESSAGES_API_ENDPOINT env var."
+msgstr ""
+
+#. Translators: Error status code & content returned from an API
+#: push/models.py:84
+#, python-format
+msgid "Status: %(status)s; Content: %(content)s"
+msgstr ""
+
+#: push/models.py:94
+msgid "VAPID p256ecdsa value; url-safe base-64 encoded."
+msgstr ""
+
+#: push/templates/push/details.html:5 push/templates/push/landing.html.py:6
+#: push/templates/push/list.html:6 push/templates/push/validation.html.py:5
+msgid "Home"
+msgstr ""
+
+#: push/templates/push/details.html:7 push/templates/push/list.html.py:8
+#: push/templates/push/validation.html:7
+msgid "Applications"
+msgstr ""
+
+#: push/templates/push/details.html:8 push/templates/push/landing.html.py:7
+#: push/templates/push/list.html:8 push/templates/push/validation.html.py:9
+msgid "Current:"
+msgstr ""
+
+#: push/templates/push/details.html:14 push/templates/push/list.html.py:63
+msgid "Key"
+msgstr ""
+
+#: push/templates/push/details.html:16 push/templates/push/list.html.py:64
+msgid "Key Status"
+msgstr ""
+
+#: push/templates/push/details.html:20 push/templates/push/list.html.py:81
+#: push/templates/push/validation.html:9
+msgid "Validate"
+msgstr ""
+
+#: push/templates/push/details.html:25
+msgid "Messages"
+msgstr ""
+
+#: push/templates/push/details.html:29
+msgid "ID"
+msgstr ""
+
+#: push/templates/push/details.html:30
+msgid "Timestamp"
+msgstr ""
+
+#: push/templates/push/details.html:31
+msgid "Size"
+msgstr ""
+
+#: push/templates/push/details.html:32
+msgid "TTL"
+msgstr ""
+
+#: push/templates/push/details.html:44
+msgid "No messages to display"
+msgstr ""
+
+#: push/templates/push/landing.html:14
+msgid "Manage push applications"
+msgstr ""
+
+#: push/templates/push/landing.html:16
+msgid "Sign in"
+msgstr ""
+
+#: push/templates/push/landing.html:16
+msgid "to track your push applications"
+msgstr ""
+
+#: push/templates/push/list.html:57
+msgid "Push Service Applications"
+msgstr ""
+
+#: push/templates/push/list.html:62
+msgid "Application Name"
+msgstr ""
+
+#: push/templates/push/list.html:88
+msgid "No push applications found."
+msgstr ""
+
+#: push/templates/push/list.html:93
+msgid "Application name:"
+msgstr ""
+
+#: push/templates/push/list.html:96
+msgid "key"
+msgstr ""
+
+#: push/templates/push/list.html:97
+msgid ""
+"The public key that the application server sends for VAPID JWT validation. "
+"This should be the exact value sent in the \\"
+msgstr ""
+
+#: push/templates/push/list.html:100
+msgid "Add Push Application"
+msgstr ""
+
+#: push/templates/push/validation.html:14
+msgid ""
+"To verify you own the signing key for your app, please sign the following "
+"token using the same key you use to sign this application's VAPID JWT, and "
+"paste the url-safe, base64-encoded value below."
+msgstr ""
+
+#: push/templates/push/validation.html:16
+msgid "Token:"
+msgstr ""
+
+#: push/templates/push/validation.html:23
+msgid "URL-safe, base64-encoded signed token:"
+msgstr ""
+
+#: push/templates/push/validation.html:29
+msgid "This application has already been validated."
+msgstr ""
+
+#: push/views.py:82
+msgid "VAPID Key validated."
+msgstr ""
+
+#: push/views.py:84
+msgid "Invalid signature."
+msgstr ""
+
+#: templates/includes/fxa_sign_in_link.html:4
+msgid "Sign in with <i class=\"fa fa-firefox\"></i> Firefox Account "
+msgstr ""
+
+#: templates/includes/fxa_sign_in_link.html:6
+msgid "Note: Using dev FxA Environment"
+msgstr ""

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -1,0 +1,227 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-03-15 22:40+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: dashboard/templates/dashboard/base.html:24
+msgid "Firefox Developer Services Dashboard"
+msgstr ""
+
+#: dashboard/templates/dashboard/base.html:33
+msgid "Manage applications"
+msgstr ""
+
+#: dashboard/templates/dashboard/base.html:58
+msgid "You are here:"
+msgstr ""
+
+#: dashboard/templates/dashboard/base.html:79
+msgid "Source on GitHub"
+msgstr ""
+
+#: dashboard/templates/dashboard/base.html:79
+msgid "Issues"
+msgstr ""
+
+#: dashboard/templates/dashboard/errors/403.html:5
+msgid "403 Permission Denied"
+msgstr ""
+
+#: dashboard/templates/dashboard/errors/404.html:5
+msgid "404 Not Found"
+msgstr ""
+
+#: dashboard/templates/dashboard/errors/500.html:5
+msgid "500 Internal Server Error"
+msgstr ""
+
+#: dashboard/templates/dashboard/home.html:9
+msgid "Monitor your apps in Firefox"
+msgstr ""
+
+#: dashboard/templates/dashboard/home.html:10
+msgid ""
+"Firefox Developer Services Dashboard shows how your apps and sites are using "
+"Mozilla services."
+msgstr ""
+
+#: dashboard/templates/dashboard/home.html:14
+msgid "Manage your applications"
+msgstr ""
+
+#: dashboard/templates/dashboard/home.html:18
+msgid ""
+"A screenshot of a push application landing page, showing messages and "
+"application metadata"
+msgstr ""
+
+#: dashboard/templates/dashboard/login.html:8
+msgid "You must sign in to access that page."
+msgstr ""
+
+#: push/models.py:29
+#, python-format
+msgid "Error communicating with Push Messages API: %s"
+msgstr ""
+
+#: push/models.py:59
+msgid "Unknown public key format specified"
+msgstr ""
+
+#: push/models.py:66
+msgid "Must set PUSH_MESSAGES_API_ENDPOINT env var."
+msgstr ""
+
+#. Translators: Error status code & content returned from an API
+#: push/models.py:84
+#, python-format
+msgid "Status: %(status)s; Content: %(content)s"
+msgstr ""
+
+#: push/models.py:94
+msgid "VAPID p256ecdsa value; url-safe base-64 encoded."
+msgstr ""
+
+#: push/templates/push/details.html:5 push/templates/push/landing.html.py:6
+#: push/templates/push/list.html:6 push/templates/push/validation.html.py:5
+msgid "Home"
+msgstr ""
+
+#: push/templates/push/details.html:7 push/templates/push/list.html.py:8
+#: push/templates/push/validation.html:7
+msgid "Applications"
+msgstr ""
+
+#: push/templates/push/details.html:8 push/templates/push/landing.html.py:7
+#: push/templates/push/list.html:8 push/templates/push/validation.html.py:9
+msgid "Current:"
+msgstr ""
+
+#: push/templates/push/details.html:14 push/templates/push/list.html.py:63
+msgid "Key"
+msgstr ""
+
+#: push/templates/push/details.html:16 push/templates/push/list.html.py:64
+msgid "Key Status"
+msgstr ""
+
+#: push/templates/push/details.html:20 push/templates/push/list.html.py:81
+#: push/templates/push/validation.html:9
+msgid "Validate"
+msgstr ""
+
+#: push/templates/push/details.html:25
+msgid "Messages"
+msgstr ""
+
+#: push/templates/push/details.html:29
+msgid "ID"
+msgstr ""
+
+#: push/templates/push/details.html:30
+msgid "Timestamp"
+msgstr ""
+
+#: push/templates/push/details.html:31
+msgid "Size"
+msgstr ""
+
+#: push/templates/push/details.html:32
+msgid "TTL"
+msgstr ""
+
+#: push/templates/push/details.html:44
+msgid "No messages to display"
+msgstr ""
+
+#: push/templates/push/landing.html:14
+msgid "Manage push applications"
+msgstr ""
+
+#: push/templates/push/landing.html:16
+msgid "Sign in"
+msgstr ""
+
+#: push/templates/push/landing.html:16
+msgid "to track your push applications"
+msgstr ""
+
+#: push/templates/push/list.html:57
+msgid "Push Service Applications"
+msgstr ""
+
+#: push/templates/push/list.html:62
+msgid "Application Name"
+msgstr ""
+
+#: push/templates/push/list.html:88
+msgid "No push applications found."
+msgstr ""
+
+#: push/templates/push/list.html:93
+msgid "Application name:"
+msgstr ""
+
+#: push/templates/push/list.html:96
+msgid "key"
+msgstr ""
+
+#: push/templates/push/list.html:97
+msgid ""
+"The public key that the application server sends for VAPID JWT validation. "
+"This should be the exact value sent in the \\"
+msgstr ""
+
+#: push/templates/push/list.html:100
+msgid "Add Push Application"
+msgstr ""
+
+#: push/templates/push/validation.html:14
+msgid ""
+"To verify you own the signing key for your app, please sign the following "
+"token using the same key you use to sign this application's VAPID JWT, and "
+"paste the url-safe, base64-encoded value below."
+msgstr ""
+
+#: push/templates/push/validation.html:16
+msgid "Token:"
+msgstr ""
+
+#: push/templates/push/validation.html:23
+msgid "URL-safe, base64-encoded signed token:"
+msgstr ""
+
+#: push/templates/push/validation.html:29
+msgid "This application has already been validated."
+msgstr ""
+
+#: push/views.py:82
+msgid "VAPID Key validated."
+msgstr ""
+
+#: push/views.py:84
+msgid "Invalid signature."
+msgstr ""
+
+#: templates/includes/fxa_sign_in_link.html:4
+msgid "Sign in with <i class=\"fa fa-firefox\"></i> Firefox Account "
+msgstr ""
+
+#: templates/includes/fxa_sign_in_link.html:6
+msgid "Note: Using dev FxA Environment"
+msgstr ""

--- a/locale/it/LC_MESSAGES/django.po
+++ b/locale/it/LC_MESSAGES/django.po
@@ -1,0 +1,227 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-03-15 22:40+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: dashboard/templates/dashboard/base.html:24
+msgid "Firefox Developer Services Dashboard"
+msgstr ""
+
+#: dashboard/templates/dashboard/base.html:33
+msgid "Manage applications"
+msgstr ""
+
+#: dashboard/templates/dashboard/base.html:58
+msgid "You are here:"
+msgstr ""
+
+#: dashboard/templates/dashboard/base.html:79
+msgid "Source on GitHub"
+msgstr ""
+
+#: dashboard/templates/dashboard/base.html:79
+msgid "Issues"
+msgstr ""
+
+#: dashboard/templates/dashboard/errors/403.html:5
+msgid "403 Permission Denied"
+msgstr ""
+
+#: dashboard/templates/dashboard/errors/404.html:5
+msgid "404 Not Found"
+msgstr ""
+
+#: dashboard/templates/dashboard/errors/500.html:5
+msgid "500 Internal Server Error"
+msgstr ""
+
+#: dashboard/templates/dashboard/home.html:9
+msgid "Monitor your apps in Firefox"
+msgstr ""
+
+#: dashboard/templates/dashboard/home.html:10
+msgid ""
+"Firefox Developer Services Dashboard shows how your apps and sites are using "
+"Mozilla services."
+msgstr ""
+
+#: dashboard/templates/dashboard/home.html:14
+msgid "Manage your applications"
+msgstr ""
+
+#: dashboard/templates/dashboard/home.html:18
+msgid ""
+"A screenshot of a push application landing page, showing messages and "
+"application metadata"
+msgstr ""
+
+#: dashboard/templates/dashboard/login.html:8
+msgid "You must sign in to access that page."
+msgstr ""
+
+#: push/models.py:29
+#, python-format
+msgid "Error communicating with Push Messages API: %s"
+msgstr ""
+
+#: push/models.py:59
+msgid "Unknown public key format specified"
+msgstr ""
+
+#: push/models.py:66
+msgid "Must set PUSH_MESSAGES_API_ENDPOINT env var."
+msgstr ""
+
+#. Translators: Error status code & content returned from an API
+#: push/models.py:84
+#, python-format
+msgid "Status: %(status)s; Content: %(content)s"
+msgstr ""
+
+#: push/models.py:94
+msgid "VAPID p256ecdsa value; url-safe base-64 encoded."
+msgstr ""
+
+#: push/templates/push/details.html:5 push/templates/push/landing.html.py:6
+#: push/templates/push/list.html:6 push/templates/push/validation.html.py:5
+msgid "Home"
+msgstr ""
+
+#: push/templates/push/details.html:7 push/templates/push/list.html.py:8
+#: push/templates/push/validation.html:7
+msgid "Applications"
+msgstr ""
+
+#: push/templates/push/details.html:8 push/templates/push/landing.html.py:7
+#: push/templates/push/list.html:8 push/templates/push/validation.html.py:9
+msgid "Current:"
+msgstr ""
+
+#: push/templates/push/details.html:14 push/templates/push/list.html.py:63
+msgid "Key"
+msgstr ""
+
+#: push/templates/push/details.html:16 push/templates/push/list.html.py:64
+msgid "Key Status"
+msgstr ""
+
+#: push/templates/push/details.html:20 push/templates/push/list.html.py:81
+#: push/templates/push/validation.html:9
+msgid "Validate"
+msgstr ""
+
+#: push/templates/push/details.html:25
+msgid "Messages"
+msgstr ""
+
+#: push/templates/push/details.html:29
+msgid "ID"
+msgstr ""
+
+#: push/templates/push/details.html:30
+msgid "Timestamp"
+msgstr ""
+
+#: push/templates/push/details.html:31
+msgid "Size"
+msgstr ""
+
+#: push/templates/push/details.html:32
+msgid "TTL"
+msgstr ""
+
+#: push/templates/push/details.html:44
+msgid "No messages to display"
+msgstr ""
+
+#: push/templates/push/landing.html:14
+msgid "Manage push applications"
+msgstr ""
+
+#: push/templates/push/landing.html:16
+msgid "Sign in"
+msgstr ""
+
+#: push/templates/push/landing.html:16
+msgid "to track your push applications"
+msgstr ""
+
+#: push/templates/push/list.html:57
+msgid "Push Service Applications"
+msgstr ""
+
+#: push/templates/push/list.html:62
+msgid "Application Name"
+msgstr ""
+
+#: push/templates/push/list.html:88
+msgid "No push applications found."
+msgstr ""
+
+#: push/templates/push/list.html:93
+msgid "Application name:"
+msgstr ""
+
+#: push/templates/push/list.html:96
+msgid "key"
+msgstr ""
+
+#: push/templates/push/list.html:97
+msgid ""
+"The public key that the application server sends for VAPID JWT validation. "
+"This should be the exact value sent in the \\"
+msgstr ""
+
+#: push/templates/push/list.html:100
+msgid "Add Push Application"
+msgstr ""
+
+#: push/templates/push/validation.html:14
+msgid ""
+"To verify you own the signing key for your app, please sign the following "
+"token using the same key you use to sign this application's VAPID JWT, and "
+"paste the url-safe, base64-encoded value below."
+msgstr ""
+
+#: push/templates/push/validation.html:16
+msgid "Token:"
+msgstr ""
+
+#: push/templates/push/validation.html:23
+msgid "URL-safe, base64-encoded signed token:"
+msgstr ""
+
+#: push/templates/push/validation.html:29
+msgid "This application has already been validated."
+msgstr ""
+
+#: push/views.py:82
+msgid "VAPID Key validated."
+msgstr ""
+
+#: push/views.py:84
+msgid "Invalid signature."
+msgstr ""
+
+#: templates/includes/fxa_sign_in_link.html:4
+msgid "Sign in with <i class=\"fa fa-firefox\"></i> Firefox Account "
+msgstr ""
+
+#: templates/includes/fxa_sign_in_link.html:6
+msgid "Note: Using dev FxA Environment"
+msgstr ""

--- a/locale/ja/LC_MESSAGES/django.po
+++ b/locale/ja/LC_MESSAGES/django.po
@@ -1,0 +1,227 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-03-15 22:40+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: dashboard/templates/dashboard/base.html:24
+msgid "Firefox Developer Services Dashboard"
+msgstr ""
+
+#: dashboard/templates/dashboard/base.html:33
+msgid "Manage applications"
+msgstr ""
+
+#: dashboard/templates/dashboard/base.html:58
+msgid "You are here:"
+msgstr ""
+
+#: dashboard/templates/dashboard/base.html:79
+msgid "Source on GitHub"
+msgstr ""
+
+#: dashboard/templates/dashboard/base.html:79
+msgid "Issues"
+msgstr ""
+
+#: dashboard/templates/dashboard/errors/403.html:5
+msgid "403 Permission Denied"
+msgstr ""
+
+#: dashboard/templates/dashboard/errors/404.html:5
+msgid "404 Not Found"
+msgstr ""
+
+#: dashboard/templates/dashboard/errors/500.html:5
+msgid "500 Internal Server Error"
+msgstr ""
+
+#: dashboard/templates/dashboard/home.html:9
+msgid "Monitor your apps in Firefox"
+msgstr ""
+
+#: dashboard/templates/dashboard/home.html:10
+msgid ""
+"Firefox Developer Services Dashboard shows how your apps and sites are using "
+"Mozilla services."
+msgstr ""
+
+#: dashboard/templates/dashboard/home.html:14
+msgid "Manage your applications"
+msgstr ""
+
+#: dashboard/templates/dashboard/home.html:18
+msgid ""
+"A screenshot of a push application landing page, showing messages and "
+"application metadata"
+msgstr ""
+
+#: dashboard/templates/dashboard/login.html:8
+msgid "You must sign in to access that page."
+msgstr ""
+
+#: push/models.py:29
+#, python-format
+msgid "Error communicating with Push Messages API: %s"
+msgstr ""
+
+#: push/models.py:59
+msgid "Unknown public key format specified"
+msgstr ""
+
+#: push/models.py:66
+msgid "Must set PUSH_MESSAGES_API_ENDPOINT env var."
+msgstr ""
+
+#. Translators: Error status code & content returned from an API
+#: push/models.py:84
+#, python-format
+msgid "Status: %(status)s; Content: %(content)s"
+msgstr ""
+
+#: push/models.py:94
+msgid "VAPID p256ecdsa value; url-safe base-64 encoded."
+msgstr ""
+
+#: push/templates/push/details.html:5 push/templates/push/landing.html.py:6
+#: push/templates/push/list.html:6 push/templates/push/validation.html.py:5
+msgid "Home"
+msgstr ""
+
+#: push/templates/push/details.html:7 push/templates/push/list.html.py:8
+#: push/templates/push/validation.html:7
+msgid "Applications"
+msgstr ""
+
+#: push/templates/push/details.html:8 push/templates/push/landing.html.py:7
+#: push/templates/push/list.html:8 push/templates/push/validation.html.py:9
+msgid "Current:"
+msgstr ""
+
+#: push/templates/push/details.html:14 push/templates/push/list.html.py:63
+msgid "Key"
+msgstr ""
+
+#: push/templates/push/details.html:16 push/templates/push/list.html.py:64
+msgid "Key Status"
+msgstr ""
+
+#: push/templates/push/details.html:20 push/templates/push/list.html.py:81
+#: push/templates/push/validation.html:9
+msgid "Validate"
+msgstr ""
+
+#: push/templates/push/details.html:25
+msgid "Messages"
+msgstr ""
+
+#: push/templates/push/details.html:29
+msgid "ID"
+msgstr ""
+
+#: push/templates/push/details.html:30
+msgid "Timestamp"
+msgstr ""
+
+#: push/templates/push/details.html:31
+msgid "Size"
+msgstr ""
+
+#: push/templates/push/details.html:32
+msgid "TTL"
+msgstr ""
+
+#: push/templates/push/details.html:44
+msgid "No messages to display"
+msgstr ""
+
+#: push/templates/push/landing.html:14
+msgid "Manage push applications"
+msgstr ""
+
+#: push/templates/push/landing.html:16
+msgid "Sign in"
+msgstr ""
+
+#: push/templates/push/landing.html:16
+msgid "to track your push applications"
+msgstr ""
+
+#: push/templates/push/list.html:57
+msgid "Push Service Applications"
+msgstr ""
+
+#: push/templates/push/list.html:62
+msgid "Application Name"
+msgstr ""
+
+#: push/templates/push/list.html:88
+msgid "No push applications found."
+msgstr ""
+
+#: push/templates/push/list.html:93
+msgid "Application name:"
+msgstr ""
+
+#: push/templates/push/list.html:96
+msgid "key"
+msgstr ""
+
+#: push/templates/push/list.html:97
+msgid ""
+"The public key that the application server sends for VAPID JWT validation. "
+"This should be the exact value sent in the \\"
+msgstr ""
+
+#: push/templates/push/list.html:100
+msgid "Add Push Application"
+msgstr ""
+
+#: push/templates/push/validation.html:14
+msgid ""
+"To verify you own the signing key for your app, please sign the following "
+"token using the same key you use to sign this application's VAPID JWT, and "
+"paste the url-safe, base64-encoded value below."
+msgstr ""
+
+#: push/templates/push/validation.html:16
+msgid "Token:"
+msgstr ""
+
+#: push/templates/push/validation.html:23
+msgid "URL-safe, base64-encoded signed token:"
+msgstr ""
+
+#: push/templates/push/validation.html:29
+msgid "This application has already been validated."
+msgstr ""
+
+#: push/views.py:82
+msgid "VAPID Key validated."
+msgstr ""
+
+#: push/views.py:84
+msgid "Invalid signature."
+msgstr ""
+
+#: templates/includes/fxa_sign_in_link.html:4
+msgid "Sign in with <i class=\"fa fa-firefox\"></i> Firefox Account "
+msgstr ""
+
+#: templates/includes/fxa_sign_in_link.html:6
+msgid "Note: Using dev FxA Environment"
+msgstr ""

--- a/locale/nl/LC_MESSAGES/django.po
+++ b/locale/nl/LC_MESSAGES/django.po
@@ -1,0 +1,227 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-03-15 22:40+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: dashboard/templates/dashboard/base.html:24
+msgid "Firefox Developer Services Dashboard"
+msgstr ""
+
+#: dashboard/templates/dashboard/base.html:33
+msgid "Manage applications"
+msgstr ""
+
+#: dashboard/templates/dashboard/base.html:58
+msgid "You are here:"
+msgstr ""
+
+#: dashboard/templates/dashboard/base.html:79
+msgid "Source on GitHub"
+msgstr ""
+
+#: dashboard/templates/dashboard/base.html:79
+msgid "Issues"
+msgstr ""
+
+#: dashboard/templates/dashboard/errors/403.html:5
+msgid "403 Permission Denied"
+msgstr ""
+
+#: dashboard/templates/dashboard/errors/404.html:5
+msgid "404 Not Found"
+msgstr ""
+
+#: dashboard/templates/dashboard/errors/500.html:5
+msgid "500 Internal Server Error"
+msgstr ""
+
+#: dashboard/templates/dashboard/home.html:9
+msgid "Monitor your apps in Firefox"
+msgstr ""
+
+#: dashboard/templates/dashboard/home.html:10
+msgid ""
+"Firefox Developer Services Dashboard shows how your apps and sites are using "
+"Mozilla services."
+msgstr ""
+
+#: dashboard/templates/dashboard/home.html:14
+msgid "Manage your applications"
+msgstr ""
+
+#: dashboard/templates/dashboard/home.html:18
+msgid ""
+"A screenshot of a push application landing page, showing messages and "
+"application metadata"
+msgstr ""
+
+#: dashboard/templates/dashboard/login.html:8
+msgid "You must sign in to access that page."
+msgstr ""
+
+#: push/models.py:29
+#, python-format
+msgid "Error communicating with Push Messages API: %s"
+msgstr ""
+
+#: push/models.py:59
+msgid "Unknown public key format specified"
+msgstr ""
+
+#: push/models.py:66
+msgid "Must set PUSH_MESSAGES_API_ENDPOINT env var."
+msgstr ""
+
+#. Translators: Error status code & content returned from an API
+#: push/models.py:84
+#, python-format
+msgid "Status: %(status)s; Content: %(content)s"
+msgstr ""
+
+#: push/models.py:94
+msgid "VAPID p256ecdsa value; url-safe base-64 encoded."
+msgstr ""
+
+#: push/templates/push/details.html:5 push/templates/push/landing.html.py:6
+#: push/templates/push/list.html:6 push/templates/push/validation.html.py:5
+msgid "Home"
+msgstr ""
+
+#: push/templates/push/details.html:7 push/templates/push/list.html.py:8
+#: push/templates/push/validation.html:7
+msgid "Applications"
+msgstr ""
+
+#: push/templates/push/details.html:8 push/templates/push/landing.html.py:7
+#: push/templates/push/list.html:8 push/templates/push/validation.html.py:9
+msgid "Current:"
+msgstr ""
+
+#: push/templates/push/details.html:14 push/templates/push/list.html.py:63
+msgid "Key"
+msgstr ""
+
+#: push/templates/push/details.html:16 push/templates/push/list.html.py:64
+msgid "Key Status"
+msgstr ""
+
+#: push/templates/push/details.html:20 push/templates/push/list.html.py:81
+#: push/templates/push/validation.html:9
+msgid "Validate"
+msgstr ""
+
+#: push/templates/push/details.html:25
+msgid "Messages"
+msgstr ""
+
+#: push/templates/push/details.html:29
+msgid "ID"
+msgstr ""
+
+#: push/templates/push/details.html:30
+msgid "Timestamp"
+msgstr ""
+
+#: push/templates/push/details.html:31
+msgid "Size"
+msgstr ""
+
+#: push/templates/push/details.html:32
+msgid "TTL"
+msgstr ""
+
+#: push/templates/push/details.html:44
+msgid "No messages to display"
+msgstr ""
+
+#: push/templates/push/landing.html:14
+msgid "Manage push applications"
+msgstr ""
+
+#: push/templates/push/landing.html:16
+msgid "Sign in"
+msgstr ""
+
+#: push/templates/push/landing.html:16
+msgid "to track your push applications"
+msgstr ""
+
+#: push/templates/push/list.html:57
+msgid "Push Service Applications"
+msgstr ""
+
+#: push/templates/push/list.html:62
+msgid "Application Name"
+msgstr ""
+
+#: push/templates/push/list.html:88
+msgid "No push applications found."
+msgstr ""
+
+#: push/templates/push/list.html:93
+msgid "Application name:"
+msgstr ""
+
+#: push/templates/push/list.html:96
+msgid "key"
+msgstr ""
+
+#: push/templates/push/list.html:97
+msgid ""
+"The public key that the application server sends for VAPID JWT validation. "
+"This should be the exact value sent in the \\"
+msgstr ""
+
+#: push/templates/push/list.html:100
+msgid "Add Push Application"
+msgstr ""
+
+#: push/templates/push/validation.html:14
+msgid ""
+"To verify you own the signing key for your app, please sign the following "
+"token using the same key you use to sign this application's VAPID JWT, and "
+"paste the url-safe, base64-encoded value below."
+msgstr ""
+
+#: push/templates/push/validation.html:16
+msgid "Token:"
+msgstr ""
+
+#: push/templates/push/validation.html:23
+msgid "URL-safe, base64-encoded signed token:"
+msgstr ""
+
+#: push/templates/push/validation.html:29
+msgid "This application has already been validated."
+msgstr ""
+
+#: push/views.py:82
+msgid "VAPID Key validated."
+msgstr ""
+
+#: push/views.py:84
+msgid "Invalid signature."
+msgstr ""
+
+#: templates/includes/fxa_sign_in_link.html:4
+msgid "Sign in with <i class=\"fa fa-firefox\"></i> Firefox Account "
+msgstr ""
+
+#: templates/includes/fxa_sign_in_link.html:6
+msgid "Note: Using dev FxA Environment"
+msgstr ""

--- a/locale/pl/LC_MESSAGES/django.po
+++ b/locale/pl/LC_MESSAGES/django.po
@@ -1,0 +1,228 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-03-15 22:40+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2);\n"
+
+#: dashboard/templates/dashboard/base.html:24
+msgid "Firefox Developer Services Dashboard"
+msgstr ""
+
+#: dashboard/templates/dashboard/base.html:33
+msgid "Manage applications"
+msgstr ""
+
+#: dashboard/templates/dashboard/base.html:58
+msgid "You are here:"
+msgstr ""
+
+#: dashboard/templates/dashboard/base.html:79
+msgid "Source on GitHub"
+msgstr ""
+
+#: dashboard/templates/dashboard/base.html:79
+msgid "Issues"
+msgstr ""
+
+#: dashboard/templates/dashboard/errors/403.html:5
+msgid "403 Permission Denied"
+msgstr ""
+
+#: dashboard/templates/dashboard/errors/404.html:5
+msgid "404 Not Found"
+msgstr ""
+
+#: dashboard/templates/dashboard/errors/500.html:5
+msgid "500 Internal Server Error"
+msgstr ""
+
+#: dashboard/templates/dashboard/home.html:9
+msgid "Monitor your apps in Firefox"
+msgstr ""
+
+#: dashboard/templates/dashboard/home.html:10
+msgid ""
+"Firefox Developer Services Dashboard shows how your apps and sites are using "
+"Mozilla services."
+msgstr ""
+
+#: dashboard/templates/dashboard/home.html:14
+msgid "Manage your applications"
+msgstr ""
+
+#: dashboard/templates/dashboard/home.html:18
+msgid ""
+"A screenshot of a push application landing page, showing messages and "
+"application metadata"
+msgstr ""
+
+#: dashboard/templates/dashboard/login.html:8
+msgid "You must sign in to access that page."
+msgstr ""
+
+#: push/models.py:29
+#, python-format
+msgid "Error communicating with Push Messages API: %s"
+msgstr ""
+
+#: push/models.py:59
+msgid "Unknown public key format specified"
+msgstr ""
+
+#: push/models.py:66
+msgid "Must set PUSH_MESSAGES_API_ENDPOINT env var."
+msgstr ""
+
+#. Translators: Error status code & content returned from an API
+#: push/models.py:84
+#, python-format
+msgid "Status: %(status)s; Content: %(content)s"
+msgstr ""
+
+#: push/models.py:94
+msgid "VAPID p256ecdsa value; url-safe base-64 encoded."
+msgstr ""
+
+#: push/templates/push/details.html:5 push/templates/push/landing.html.py:6
+#: push/templates/push/list.html:6 push/templates/push/validation.html.py:5
+msgid "Home"
+msgstr ""
+
+#: push/templates/push/details.html:7 push/templates/push/list.html.py:8
+#: push/templates/push/validation.html:7
+msgid "Applications"
+msgstr ""
+
+#: push/templates/push/details.html:8 push/templates/push/landing.html.py:7
+#: push/templates/push/list.html:8 push/templates/push/validation.html.py:9
+msgid "Current:"
+msgstr ""
+
+#: push/templates/push/details.html:14 push/templates/push/list.html.py:63
+msgid "Key"
+msgstr ""
+
+#: push/templates/push/details.html:16 push/templates/push/list.html.py:64
+msgid "Key Status"
+msgstr ""
+
+#: push/templates/push/details.html:20 push/templates/push/list.html.py:81
+#: push/templates/push/validation.html:9
+msgid "Validate"
+msgstr ""
+
+#: push/templates/push/details.html:25
+msgid "Messages"
+msgstr ""
+
+#: push/templates/push/details.html:29
+msgid "ID"
+msgstr ""
+
+#: push/templates/push/details.html:30
+msgid "Timestamp"
+msgstr ""
+
+#: push/templates/push/details.html:31
+msgid "Size"
+msgstr ""
+
+#: push/templates/push/details.html:32
+msgid "TTL"
+msgstr ""
+
+#: push/templates/push/details.html:44
+msgid "No messages to display"
+msgstr ""
+
+#: push/templates/push/landing.html:14
+msgid "Manage push applications"
+msgstr ""
+
+#: push/templates/push/landing.html:16
+msgid "Sign in"
+msgstr ""
+
+#: push/templates/push/landing.html:16
+msgid "to track your push applications"
+msgstr ""
+
+#: push/templates/push/list.html:57
+msgid "Push Service Applications"
+msgstr ""
+
+#: push/templates/push/list.html:62
+msgid "Application Name"
+msgstr ""
+
+#: push/templates/push/list.html:88
+msgid "No push applications found."
+msgstr ""
+
+#: push/templates/push/list.html:93
+msgid "Application name:"
+msgstr ""
+
+#: push/templates/push/list.html:96
+msgid "key"
+msgstr ""
+
+#: push/templates/push/list.html:97
+msgid ""
+"The public key that the application server sends for VAPID JWT validation. "
+"This should be the exact value sent in the \\"
+msgstr ""
+
+#: push/templates/push/list.html:100
+msgid "Add Push Application"
+msgstr ""
+
+#: push/templates/push/validation.html:14
+msgid ""
+"To verify you own the signing key for your app, please sign the following "
+"token using the same key you use to sign this application's VAPID JWT, and "
+"paste the url-safe, base64-encoded value below."
+msgstr ""
+
+#: push/templates/push/validation.html:16
+msgid "Token:"
+msgstr ""
+
+#: push/templates/push/validation.html:23
+msgid "URL-safe, base64-encoded signed token:"
+msgstr ""
+
+#: push/templates/push/validation.html:29
+msgid "This application has already been validated."
+msgstr ""
+
+#: push/views.py:82
+msgid "VAPID Key validated."
+msgstr ""
+
+#: push/views.py:84
+msgid "Invalid signature."
+msgstr ""
+
+#: templates/includes/fxa_sign_in_link.html:4
+msgid "Sign in with <i class=\"fa fa-firefox\"></i> Firefox Account "
+msgstr ""
+
+#: templates/includes/fxa_sign_in_link.html:6
+msgid "Note: Using dev FxA Environment"
+msgstr ""

--- a/locale/ru/LC_MESSAGES/django.po
+++ b/locale/ru/LC_MESSAGES/django.po
@@ -1,0 +1,229 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-03-15 22:40+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n"
+"%100>=11 && n%100<=14)? 2 : 3);\n"
+
+#: dashboard/templates/dashboard/base.html:24
+msgid "Firefox Developer Services Dashboard"
+msgstr ""
+
+#: dashboard/templates/dashboard/base.html:33
+msgid "Manage applications"
+msgstr ""
+
+#: dashboard/templates/dashboard/base.html:58
+msgid "You are here:"
+msgstr ""
+
+#: dashboard/templates/dashboard/base.html:79
+msgid "Source on GitHub"
+msgstr ""
+
+#: dashboard/templates/dashboard/base.html:79
+msgid "Issues"
+msgstr ""
+
+#: dashboard/templates/dashboard/errors/403.html:5
+msgid "403 Permission Denied"
+msgstr ""
+
+#: dashboard/templates/dashboard/errors/404.html:5
+msgid "404 Not Found"
+msgstr ""
+
+#: dashboard/templates/dashboard/errors/500.html:5
+msgid "500 Internal Server Error"
+msgstr ""
+
+#: dashboard/templates/dashboard/home.html:9
+msgid "Monitor your apps in Firefox"
+msgstr ""
+
+#: dashboard/templates/dashboard/home.html:10
+msgid ""
+"Firefox Developer Services Dashboard shows how your apps and sites are using "
+"Mozilla services."
+msgstr ""
+
+#: dashboard/templates/dashboard/home.html:14
+msgid "Manage your applications"
+msgstr ""
+
+#: dashboard/templates/dashboard/home.html:18
+msgid ""
+"A screenshot of a push application landing page, showing messages and "
+"application metadata"
+msgstr ""
+
+#: dashboard/templates/dashboard/login.html:8
+msgid "You must sign in to access that page."
+msgstr ""
+
+#: push/models.py:29
+#, python-format
+msgid "Error communicating with Push Messages API: %s"
+msgstr ""
+
+#: push/models.py:59
+msgid "Unknown public key format specified"
+msgstr ""
+
+#: push/models.py:66
+msgid "Must set PUSH_MESSAGES_API_ENDPOINT env var."
+msgstr ""
+
+#. Translators: Error status code & content returned from an API
+#: push/models.py:84
+#, python-format
+msgid "Status: %(status)s; Content: %(content)s"
+msgstr ""
+
+#: push/models.py:94
+msgid "VAPID p256ecdsa value; url-safe base-64 encoded."
+msgstr ""
+
+#: push/templates/push/details.html:5 push/templates/push/landing.html.py:6
+#: push/templates/push/list.html:6 push/templates/push/validation.html.py:5
+msgid "Home"
+msgstr ""
+
+#: push/templates/push/details.html:7 push/templates/push/list.html.py:8
+#: push/templates/push/validation.html:7
+msgid "Applications"
+msgstr ""
+
+#: push/templates/push/details.html:8 push/templates/push/landing.html.py:7
+#: push/templates/push/list.html:8 push/templates/push/validation.html.py:9
+msgid "Current:"
+msgstr ""
+
+#: push/templates/push/details.html:14 push/templates/push/list.html.py:63
+msgid "Key"
+msgstr ""
+
+#: push/templates/push/details.html:16 push/templates/push/list.html.py:64
+msgid "Key Status"
+msgstr ""
+
+#: push/templates/push/details.html:20 push/templates/push/list.html.py:81
+#: push/templates/push/validation.html:9
+msgid "Validate"
+msgstr ""
+
+#: push/templates/push/details.html:25
+msgid "Messages"
+msgstr ""
+
+#: push/templates/push/details.html:29
+msgid "ID"
+msgstr ""
+
+#: push/templates/push/details.html:30
+msgid "Timestamp"
+msgstr ""
+
+#: push/templates/push/details.html:31
+msgid "Size"
+msgstr ""
+
+#: push/templates/push/details.html:32
+msgid "TTL"
+msgstr ""
+
+#: push/templates/push/details.html:44
+msgid "No messages to display"
+msgstr ""
+
+#: push/templates/push/landing.html:14
+msgid "Manage push applications"
+msgstr ""
+
+#: push/templates/push/landing.html:16
+msgid "Sign in"
+msgstr ""
+
+#: push/templates/push/landing.html:16
+msgid "to track your push applications"
+msgstr ""
+
+#: push/templates/push/list.html:57
+msgid "Push Service Applications"
+msgstr ""
+
+#: push/templates/push/list.html:62
+msgid "Application Name"
+msgstr ""
+
+#: push/templates/push/list.html:88
+msgid "No push applications found."
+msgstr ""
+
+#: push/templates/push/list.html:93
+msgid "Application name:"
+msgstr ""
+
+#: push/templates/push/list.html:96
+msgid "key"
+msgstr ""
+
+#: push/templates/push/list.html:97
+msgid ""
+"The public key that the application server sends for VAPID JWT validation. "
+"This should be the exact value sent in the \\"
+msgstr ""
+
+#: push/templates/push/list.html:100
+msgid "Add Push Application"
+msgstr ""
+
+#: push/templates/push/validation.html:14
+msgid ""
+"To verify you own the signing key for your app, please sign the following "
+"token using the same key you use to sign this application's VAPID JWT, and "
+"paste the url-safe, base64-encoded value below."
+msgstr ""
+
+#: push/templates/push/validation.html:16
+msgid "Token:"
+msgstr ""
+
+#: push/templates/push/validation.html:23
+msgid "URL-safe, base64-encoded signed token:"
+msgstr ""
+
+#: push/templates/push/validation.html:29
+msgid "This application has already been validated."
+msgstr ""
+
+#: push/views.py:82
+msgid "VAPID Key validated."
+msgstr ""
+
+#: push/views.py:84
+msgid "Invalid signature."
+msgstr ""
+
+#: templates/includes/fxa_sign_in_link.html:4
+msgid "Sign in with <i class=\"fa fa-firefox\"></i> Firefox Account "
+msgstr ""
+
+#: templates/includes/fxa_sign_in_link.html:6
+msgid "Note: Using dev FxA Environment"
+msgstr ""

--- a/push/models.py
+++ b/push/models.py
@@ -11,6 +11,7 @@ from django.contrib.auth.models import User
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 from django.utils import timezone
+from django.utils.translation import ugettext_lazy as _
 
 from .managers import PushApplicationManager
 
@@ -25,7 +26,7 @@ VAPID_KEY_STATUS_CHOICES = (
 class MessagesAPIError(Exception):
     def __init__(self, message):
         super(Exception, self).__init__(
-            "Error communicating with Push Messages API: %s" % message
+            _("Error communicating with Push Messages API: %s") % message
         )
 
 
@@ -55,14 +56,14 @@ def extract_public_key(key_data):
     # key format is "spki"
     if key_len == 88 and key_data[:3] == '0V0':
         return key_data[-64:]
-    raise ValueError("Unknown public key format specified")
+    raise ValueError(_("Unknown public key format specified"))
 
 
 def get_autopush_endpoint():
     endpoint = getattr(settings, 'PUSH_MESSAGES_API_ENDPOINT', None)
     if not endpoint:
         raise ImproperlyConfigured(
-            "Must set PUSH_MESSAGES_API_ENDPOINT env var."
+            _("Must set PUSH_MESSAGES_API_ENDPOINT env var.")
         )
     return endpoint
 
@@ -78,8 +79,10 @@ def push_messages_api_request(method, endpoint, json_data=None):
     if resp.status_code == 200:
         return resp.json()
     else:
-        raise MessagesAPIError("Status: %s; Content: %s" % (
-            resp.status_code, resp.content)
+        raise MessagesAPIError(
+            # Translators: Error status code & content returned from an API
+            _("Status: %(status)s; Content: %(content)s") %
+            {'status': resp.status_code, 'content': resp.content}
         )
 
 
@@ -88,7 +91,7 @@ class PushApplication(models.Model):
     name = models.CharField(max_length=255)
     vapid_key = models.CharField(
         blank=False, max_length=255,
-        help_text="VAPID p256ecdsa value; url-safe base-64 encoded."
+        help_text=_("VAPID p256ecdsa value; url-safe base-64 encoded.")
     )
     vapid_key_status = models.CharField(max_length=255,
                                         default='pending',

--- a/push/templates/push/details.html
+++ b/push/templates/push/details.html
@@ -1,34 +1,35 @@
 {% extends "dashboard/base.html" %}
+{% load i18n %}
 
 {% block breadcrumbs %}
-<li><a href="{% url 'home' %}">Home</a></li>
+<li><a href="{% url 'home' %}">{% trans "Home" %}</a></li>
 <li><a href="{% url 'push.landing' %}">Push</a></li>
-<li><a href="{% url 'push.list' %}">Applications</a></li>
-<li><span class="show-for-sr">Current: </span>{{ app.name }}</li>
+<li><a href="{% url 'push.list' %}">{% trans "Applications" %}</a></li>
+<li><span class="show-for-sr">{% trans "Current:" %} </span>{{ app.name }}</li>
 {% endblock %}
 
 {% block content %}
     <h2>{{ app.name }}</h2>
     <dl id="push-app-info">
-        <dt>VAPID Key</dt>
+        <dt>VAPID {% trans "Key" %}</dt>
         <dd>{{ app.vapid_key }}</dd>
-        <dt>VAPID Key Status</dt>
+        <dt>VAPID {% trans "Key Status" %}</dt>
         <dd>
             {{ app.vapid_key_status }}
             {% if app.can_validate %}
-                <a class="validate button" href="{% url 'push.validation' app.id %}">Validate</a>
+            <a class="validate button" href="{% url 'push.validation' app.id %}">{% trans "Validate" %}</a>
             {% endif %}
         </dd>
     </dl>
     {% if app.recording %}
-    <h3>Messages</h3>
+    <h3>{% trans "Messages" %}</h3>
     <table>
         <thead>
             <tr>
-                <th>ID</th>
-                <th>Timestamp</th>
-                <th>Size</th>
-                <th>TTL</th>
+                <th>{% trans "ID" %}</th>
+                <th>{% trans "Timestamp" %}</th>
+                <th>{% trans "Size" %}</th>
+                <th>{% trans "TTL" %}</th>
             </tr>
         </thead>
         <tbody>
@@ -40,7 +41,7 @@
                 <td>{{ message.ttl }}</td>
             </tr>
         {% empty %}
-            <tr><td colspan="4">No messages to display</td></tr>
+        <tr><td colspan="4">{% trans "No messages to display" %}</td></tr>
         {% endfor %}
         </tbody>
     </table>

--- a/push/templates/push/landing.html
+++ b/push/templates/push/landing.html
@@ -1,18 +1,19 @@
 {% extends "dashboard/base.html" %}
+{% load i18n %}
 {% load socialaccount %}
 
 {% block breadcrumbs %}
-<li><a href="{% url 'home' %}">Home</a></li>
-<li><span class="show-for-sr">Current: </span>Push</li>
+<li><a href="{% url 'home' %}">{% trans "Home" %}</a></li>
+<li><span class="show-for-sr">{% trans "Current:" %} </span>Push</li>
 {% endblock %}
 
 {% block content %}
     <iframe id="datadog" src="https://p.datadoghq.com/sb/NsBIKn-0f8bfd3083" seamless="seamless" scrolling="no"></iframe>
     <div id="cta">
         {% if request.user.is_authenticated %}
-            <a class="button" href="{% url 'push.list' %}">Manage push applications</a>
+        <a class="button" href="{% url 'push.list' %}">{% trans "Manage push applications" %}</a>
         {% else %}
-        <p><a href="{% provider_login_url "fxa" %}?next={{ request.path }}">Sign in</a> to track your push applications</p>
+        <p><a href="{% provider_login_url "fxa" %}?next={{ request.path }}">{% trans "Sign in" %}</a> {% trans "to track your push applications" %}</p>
         {% endif %}
     </div>
 {% endblock %}

--- a/push/templates/push/list.html
+++ b/push/templates/push/list.html
@@ -1,10 +1,11 @@
 {% extends "dashboard/base.html" %}
+{% load i18n %}
 {% load waffle_tags %}
 
 {% block breadcrumbs %}
-<li><a href="{% url 'home' %}">Home</a></li>
+<li><a href="{% url 'home' %}">{% trans "Home" %}</a></li>
 <li><a href="{% url 'push.landing' %}">Push</a></li>
-<li><span class="show-for-sr">Current: </span>Applications</li>
+<li><span class="show-for-sr">{% trans "Current:"%}</span>{% trans "Applications" %}</li>
 {% endblock %}
 
 {% block content %}
@@ -62,14 +63,14 @@
 
     <section id="push-applications">
         <section id="push-applications-list">
-            <h2>Push Applications</h2>
+            <h2>{% trans "Push Applications" %}</h2>
             {% if push_apps %}
                 <table>
                     <thead>
                         <tr>
-                            <th>Application Name</th>
-                            <th>VAPID Key</th>
-                            <th>VAPID Key Status</th>
+                            <th>{% trans "Application Name" %}</th>
+                            <th>VAPID {% trans "Key" %}</th>
+                            <th>VAPID {% trans "Key Status" %}</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -93,23 +94,23 @@
                     </tbody>
                 </table>
             {% else %}
-                <p>No push applications have been registered. Use the form below to add some.</p>
+            <p>{% trans "No push applications have been registered. Use the form below to add some." %}</p>
             {% endif %}
         </section> {# push-applications-list #}
 
         <section id="add-push-application">
-            <h2>Add Push Application</h2>
+            <h2>{% trans "Add Push Application" %}</h2>
             <form action="{% url 'pushapplication-list' %}" method="POST" autocomplete="off">
                 {% csrf_token %}
 
-                <label for="{{ push_app_form.name.auto_id }}">Application name:</label>
+                <label for="{{ push_app_form.name.auto_id }}">{% trans "Application name:" %}</label>
                 {{ push_app_form.name }}
 
-                <label for="{{ push_app_form.vapid_key.auto_id }}">VAPID key:</label>
-                <span class="question-mark-tip has-tip [tip-top]" data-tooltip="data-tooltip" aria-haspopup="true" title='The public key that the application server sends for VAPID JWT validation. This should be the exact value sent in the "p256ecdsa" parameter of the Crypto-Key header of the POST requests to the push server.'></span>
+                <label for="{{ push_app_form.vapid_key.auto_id }}">VAPID {% trans "key:" %}</label>
+                <span class="question-mark-tip has-tip [tip-top]" data-tooltip="data-tooltip" aria-haspopup="true" title='{% trans "The public key that the application server sends for VAPID JWT validation. This should be the exact value sent in the \"p256ecdsa\" parameter of the Crypto-Key header of the POST requests to the push server." %}'></span>
                 {{ push_app_form.vapid_key }}
 
-                <input type="submit" class="button" value="Add">
+                <input type="submit" class="button" value="{% trans "Add" %}">
             </form>
         </section> {# add-push-application #}
     </section> {# push-applications #}

--- a/push/templates/push/validation.html
+++ b/push/templates/push/validation.html
@@ -1,31 +1,32 @@
 {% extends "dashboard/base.html" %}
+{% load i18n %}
 
 {% block breadcrumbs %}
-<li><a href="{% url 'home' %}">Home</a></li>
+<li><a href="{% url 'home' %}">{% trans "Home" %}</a></li>
 <li><a href="{% url 'push.landing' %}">Push</a></li>
-<li><a href="{% url 'push.list' %}">Applications</a></li>
+<li><a href="{% url 'push.list' %}">{% trans "Applications" %}</a></li>
 <li><a href="{% url 'push.details' app.id %}">{{ app.name }}</a></li>
-<li><span class="show-for-sr">Current: </span>Validate</li>
+<li><span class="show-for-sr">{% trans "Current:" %} </span>{% trans "Validate" %}</li>
 {% endblock %}
 
 {% block content %}
     {% if not app.valid %}
-        <p>To verify you own the signing key for your app, please sign the following token using the same key you use to sign this application's VAPID JWT, and paste the url-safe, base64-encoded value below.</p>
+    <p>{% trans "To verify you own the signing key for your app, please sign the following token using the same key you use to sign this application's VAPID JWT, and paste the url-safe, base64-encoded value below." %}</p>
         <dl>
-            <dt>Token:</dt>
+            <dt>{% trans "Token:" %}</dt>
             <dd>{{ app.vapid_key_token }}</dd>
         </dl>
 
         <form id="vapid-validation" action="{% url 'push.validation' app.id %}" method="POST">
             {% csrf_token %}
 
-            <label for="{{ vapid_validation_form.signed_token.auto_id }}">URL-safe, base64-encoded signed token:</label>
+            <label for="{{ vapid_validation_form.signed_token.auto_id }}">{% trans "URL-safe, base64-encoded signed token:" %}</label>
             {{ vapid_validation_form.signed_token }}
 
             <input type="submit" class="button" value="Validate">
         </form>
     {% else %}
-        <p>This application has already been validated.</p>
+        <p>{% trans "This application has already been validated." %}</p>
         <a class="button" href="{% url 'push.details' app.id %}">View application</a>
     {% endif %}
 {% endblock %}

--- a/push/views.py
+++ b/push/views.py
@@ -1,7 +1,8 @@
 from django.contrib import messages
-from django.shortcuts import get_object_or_404, redirect
-from django.views.generic import TemplateView
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
+from django.shortcuts import get_object_or_404, redirect
+from django.utils.translation import ugettext as _
+from django.views.generic import TemplateView
 
 from domains.forms import DomainAuthForm
 from domains.models import DomainAuthorization
@@ -78,7 +79,7 @@ class Validation(UserOwnsPushAppMixin, TemplateView):
         push_app = get_object_or_404(PushApplication, pk=pk)
         push_app.validate_vapid_key(request.POST["signed_token"])
         if push_app.valid:
-            messages.success(self.request, "VAPID Key validated.")
+            messages.success(self.request, _("VAPID Key validated."))
         elif push_app.invalid:
-            messages.warning(self.request, "Invalid signature.")
+            messages.warning(self.request, _("Invalid signature."))
         return redirect('push.details', pk=pk)

--- a/templates/includes/fxa_sign_in_link.html
+++ b/templates/includes/fxa_sign_in_link.html
@@ -1,7 +1,8 @@
+{% load i18n %}
 {% load socialaccount %}
 <div class="sign-in-area">
-    <a class="button sign-in-btn" href="{% provider_login_url "fxa" %}?next={{ request.path }}">Sign in with <i class="fa fa-firefox"></i> Firefox Account</a>
+    <a class="button sign-in-btn" href="{% provider_login_url "fxa" %}?next={{ request.path }}">{% blocktrans %}Sign in with <i class="fa fa-firefox"></i> Firefox Account{% endblocktrans %}</a>
     {% if 'dev.lcip.org' in settings.SOCIALACCOUNT_PROVIDERS.fxa.OAUTH_ENDPOINT %}
-    <div class="callout warning sign-in-tooltip">Note: Using dev FxA Environment</div>
+    <div class="callout warning sign-in-tooltip">{% trans "Note: Using dev FxA Environment" %}</div>
     {% endif %}
 </div>


### PR DESCRIPTION
Picking 8 starting languages by popularity of Push API articles on MDN

Spot-check:
1. Edit one of the locale's `django.po` file - "translate" a `msgstr` value
   - e.g., in `locale/de/LC_MESSAGES/django.po`:
   - `~ msgstr "Firefox Developer Zervices Dashboard"`
2. Run `python manage.py compilemessages` to generate the corresponding `django.mo` file
3. Add German(de) to your browser as your top language
4. Go to the main page.
   - [ ] "Firefox Developer Services Dashboard" should be "translated" into "Firefox Developer Zervices Dashboard"
