### PR TITLE
Move JavaScript from /apps to external file

### DIFF
--- a/dashboard/settings.py
+++ b/dashboard/settings.py
@@ -180,8 +180,12 @@ PIPELINE = {
     'JAVASCRIPT': {
         'dashboard': {
             'source_filenames': (
+                # Global
                 'js/analytics.js',
-                'js/sign_in.js'
+                'js/sign_in.js',
+
+                # Push application listing page
+                'js/add-push-application.js',
             ),
             'output_filename': 'js/dashboard.js'
         }

--- a/push/static/js/add-push-application.js
+++ b/push/static/js/add-push-application.js
@@ -1,0 +1,33 @@
+function formSubmit(e) {
+    'use strict';
+
+    e.preventDefault();
+    var $form = $(this);
+    var csrf_token = $form.find('input[name=csrfmiddlewaretoken]').val();
+    var api_call = $.ajax({
+        url: $form.attr('action'),
+        method: $form.attr('method'),
+        data: $form.serialize(),
+        processData: false,
+        headers: {
+            'X-CSRFToken': csrf_token
+        },
+        contentType: 'application/x-www-form-urlencoded; charset=UTF-8'
+    });
+
+    api_call.fail(function(jqXHR) {
+        $.each(jqXHR.responseJSON, function(index, element) {
+            $('#id_' + index).after('<div class="alert callout">' + element + '</div>');
+        });
+    });
+
+    api_call.success(function() {
+        window.location.reload();
+    });
+}
+
+$(document).ready(function() {
+    'use strict';
+
+    $('form').submit(formSubmit);
+});

--- a/push/templates/push/list.html
+++ b/push/templates/push/list.html
@@ -99,37 +99,3 @@
         <input type="submit" class="button" value="Add Push Application">
     </form>
 {% endblock %}
-
-{% block post_script %}
-<script>
-function formSubmit(e) {
-    e.preventDefault();
-    var $form = $(this);
-    var csrf_token = $form.find('input[name=csrfmiddlewaretoken]').val();
-    var api_call = $.ajax({
-        url: $form.attr('action'),
-        method: $form.attr('method'),
-        data: $form.serialize(),
-        processData: false,
-        headers: {
-            'X-CSRFToken': csrf_token
-        },
-        contentType: 'application/x-www-form-urlencoded; charset=UTF-8'
-    });
-
-    api_call.fail(function(jqXHR) {
-      $.each(jqXHR.responseJSON, function(index, element) {
-        $('#id_' + index).after('<div class="alert callout">' + element + '</div>');
-      });
-    });
-
-    api_call.success(function() {
-        window.location.reload();
-    });
-}
-
-$(document).ready(function() {
-    $('form').submit(formSubmit);
-});
-</script>
-{% endblock %}


### PR DESCRIPTION
Moving this to an external file allows us to take advantage of eslint,
JavaScript compression, and optimized caching settings from WhiteNoise.
