### PR TITLE
Don't wrap JavaScript using Pipeline

### DIFF
--- a/dashboard/settings.py
+++ b/dashboard/settings.py
@@ -155,6 +155,7 @@ STATICFILES_FINDERS = (
 )
 
 # django-pipeline
+DISABLE_WRAPPER = True
 PIPELINE = {
     'STYLESHEETS': {
         'dashboard': {


### PR DESCRIPTION
By default, Pipeline wraps all JavaScript in an anonymous function to
prevent the global namespace from being polluted. We don't need this
feature right now and, just like on MDN, I'd prefer not to rely on
Pipeline for this. It's easy enough for us to do manually.
