### PR TITLE
for #133: fix sign-in url and trans block

### DIFF
--- a/dashboard/static/styles/login.styl
+++ b/dashboard/static/styles/login.styl
@@ -1,3 +1,8 @@
+.fa-firefox {
+    margin-right: .5em;
+    vertical-align: baseline;
+}
+
 #sign-in-notice {
     text-align: center;
 }

--- a/dashboard/static/styles/navigation.styl
+++ b/dashboard/static/styles/navigation.styl
@@ -14,11 +14,6 @@
     float: right;
 }
 
-#account-management .fa-firefox {
-    margin-right: 0;
-    vertical-align: baseline;
-}
-
 .top-bar nav ul {
     background-color: transparent;
 }

--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -2,13 +2,13 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-23 21:00+0000\n"
+"POT-Creation-Date: 2016-03-25 15:21+0000\n"
 "PO-Revision-Date: 2016-03-24 17:50+0000\n"
 "Last-Translator: Matjaž Horvat <matjaz.horvat@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -66,8 +66,8 @@ msgstr ""
 
 #: dashboard/templates/dashboard/home.html:10
 msgid ""
-"Firefox Developer Services Dashboard shows how your apps and sites are using"
-" Mozilla services."
+"Firefox Developer Services Dashboard shows how your apps and sites are using "
+"Mozilla services."
 msgstr ""
 
 #: dashboard/templates/dashboard/home.html:14
@@ -131,8 +131,7 @@ msgid "Key Status"
 msgstr ""
 
 #: push/templates/push/details.html:20 push/templates/push/list.html.py:90
-#: push/templates/push/validation.html:9
-#: push/templates/push/validation.html:26
+#: push/templates/push/validation.html:9 push/templates/push/validation.html:26
 msgid "Validate"
 msgstr ""
 
@@ -162,13 +161,6 @@ msgstr ""
 
 #: push/templates/push/landing.html:14
 msgid "Manage push applications"
-msgstr ""
-
-#: push/templates/push/landing.html:16
-#, python-format
-msgid ""
-"<a href=\"%(href)s?next=%(request.path)s\">Sign in</a> to track your push "
-"applications "
 msgstr ""
 
 #: push/templates/push/list.html:20
@@ -262,14 +254,10 @@ msgstr ""
 msgid "404 Not Found"
 msgstr ""
 
-#. Translators: the <i></i> is a firefox icon in the middle of the phrase.
-#: templates/includes/fxa_sign_in_link.html:5
-#, python-format
-msgid ""
-"<a class=\"button sign-in-btn\" href=\"%(href)s?next=%(request.path)s\">Sign"
-" in with <i class=\"fa fa-firefox\"></i> Firefox Account</a>"
+#: templates/includes/fxa_sign_in_link.html:4
+msgid "Sign in with Firefox Account"
 msgstr ""
 
-#: templates/includes/fxa_sign_in_link.html:7
+#: templates/includes/fxa_sign_in_link.html:6
 msgid "Note: Using dev FxA Environment"
 msgstr ""

--- a/locale/django.pot
+++ b/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-23 21:00+0000\n"
+"POT-Creation-Date: 2016-03-25 15:21+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -161,13 +161,6 @@ msgstr ""
 msgid "Manage push applications"
 msgstr ""
 
-#: push/templates/push/landing.html:16
-#, python-format
-msgid ""
-"<a href=\"%(href)s?next=%(request.path)s\">Sign in</a> to track your push "
-"applications "
-msgstr ""
-
 #: push/templates/push/list.html:20
 msgid "Domain"
 msgstr ""
@@ -259,14 +252,10 @@ msgstr ""
 msgid "404 Not Found"
 msgstr ""
 
-#. Translators: the <i></i> is a firefox icon in the middle of the phrase.
-#: templates/includes/fxa_sign_in_link.html:5
-#, python-format
-msgid ""
-"<a class=\"button sign-in-btn\" href=\"%(href)s?next=%(request.path)s\">Sign "
-"in with <i class=\"fa fa-firefox\"></i> Firefox Account</a>"
+#: templates/includes/fxa_sign_in_link.html:4
+msgid "Sign in with Firefox Account"
 msgstr ""
 
-#: templates/includes/fxa_sign_in_link.html:7
+#: templates/includes/fxa_sign_in_link.html:6
 msgid "Note: Using dev FxA Environment"
 msgstr ""

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-23 21:00+0000\n"
+"POT-Creation-Date: 2016-03-25 15:21+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -162,13 +162,6 @@ msgstr ""
 msgid "Manage push applications"
 msgstr ""
 
-#: push/templates/push/landing.html:16
-#, python-format
-msgid ""
-"<a href=\"%(href)s?next=%(request.path)s\">Sign in</a> to track your push "
-"applications "
-msgstr ""
-
 #: push/templates/push/list.html:20
 msgid "Domain"
 msgstr ""
@@ -260,14 +253,10 @@ msgstr ""
 msgid "404 Not Found"
 msgstr ""
 
-#. Translators: the <i></i> is a firefox icon in the middle of the phrase.
-#: templates/includes/fxa_sign_in_link.html:5
-#, python-format
-msgid ""
-"<a class=\"button sign-in-btn\" href=\"%(href)s?next=%(request.path)s\">Sign "
-"in with <i class=\"fa fa-firefox\"></i> Firefox Account</a>"
+#: templates/includes/fxa_sign_in_link.html:4
+msgid "Sign in with Firefox Account"
 msgstr ""
 
-#: templates/includes/fxa_sign_in_link.html:7
+#: templates/includes/fxa_sign_in_link.html:6
 msgid "Note: Using dev FxA Environment"
 msgstr ""

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-23 21:00+0000\n"
+"POT-Creation-Date: 2016-03-25 15:21+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -162,13 +162,6 @@ msgstr ""
 msgid "Manage push applications"
 msgstr ""
 
-#: push/templates/push/landing.html:16
-#, python-format
-msgid ""
-"<a href=\"%(href)s?next=%(request.path)s\">Sign in</a> to track your push "
-"applications "
-msgstr ""
-
 #: push/templates/push/list.html:20
 msgid "Domain"
 msgstr ""
@@ -260,14 +253,10 @@ msgstr ""
 msgid "404 Not Found"
 msgstr ""
 
-#. Translators: the <i></i> is a firefox icon in the middle of the phrase.
-#: templates/includes/fxa_sign_in_link.html:5
-#, python-format
-msgid ""
-"<a class=\"button sign-in-btn\" href=\"%(href)s?next=%(request.path)s\">Sign "
-"in with <i class=\"fa fa-firefox\"></i> Firefox Account</a>"
+#: templates/includes/fxa_sign_in_link.html:4
+msgid "Sign in with Firefox Account"
 msgstr ""
 
-#: templates/includes/fxa_sign_in_link.html:7
+#: templates/includes/fxa_sign_in_link.html:6
 msgid "Note: Using dev FxA Environment"
 msgstr ""

--- a/locale/it/LC_MESSAGES/django.po
+++ b/locale/it/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-23 21:00+0000\n"
+"POT-Creation-Date: 2016-03-25 15:21+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -162,13 +162,6 @@ msgstr ""
 msgid "Manage push applications"
 msgstr ""
 
-#: push/templates/push/landing.html:16
-#, python-format
-msgid ""
-"<a href=\"%(href)s?next=%(request.path)s\">Sign in</a> to track your push "
-"applications "
-msgstr ""
-
 #: push/templates/push/list.html:20
 msgid "Domain"
 msgstr ""
@@ -260,14 +253,10 @@ msgstr ""
 msgid "404 Not Found"
 msgstr ""
 
-#. Translators: the <i></i> is a firefox icon in the middle of the phrase.
-#: templates/includes/fxa_sign_in_link.html:5
-#, python-format
-msgid ""
-"<a class=\"button sign-in-btn\" href=\"%(href)s?next=%(request.path)s\">Sign "
-"in with <i class=\"fa fa-firefox\"></i> Firefox Account</a>"
+#: templates/includes/fxa_sign_in_link.html:4
+msgid "Sign in with Firefox Account"
 msgstr ""
 
-#: templates/includes/fxa_sign_in_link.html:7
+#: templates/includes/fxa_sign_in_link.html:6
 msgid "Note: Using dev FxA Environment"
 msgstr ""

--- a/locale/ja/LC_MESSAGES/django.po
+++ b/locale/ja/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-23 21:00+0000\n"
+"POT-Creation-Date: 2016-03-25 15:21+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -162,13 +162,6 @@ msgstr ""
 msgid "Manage push applications"
 msgstr ""
 
-#: push/templates/push/landing.html:16
-#, python-format
-msgid ""
-"<a href=\"%(href)s?next=%(request.path)s\">Sign in</a> to track your push "
-"applications "
-msgstr ""
-
 #: push/templates/push/list.html:20
 msgid "Domain"
 msgstr ""
@@ -260,14 +253,10 @@ msgstr ""
 msgid "404 Not Found"
 msgstr ""
 
-#. Translators: the <i></i> is a firefox icon in the middle of the phrase.
-#: templates/includes/fxa_sign_in_link.html:5
-#, python-format
-msgid ""
-"<a class=\"button sign-in-btn\" href=\"%(href)s?next=%(request.path)s\">Sign "
-"in with <i class=\"fa fa-firefox\"></i> Firefox Account</a>"
+#: templates/includes/fxa_sign_in_link.html:4
+msgid "Sign in with Firefox Account"
 msgstr ""
 
-#: templates/includes/fxa_sign_in_link.html:7
+#: templates/includes/fxa_sign_in_link.html:6
 msgid "Note: Using dev FxA Environment"
 msgstr ""

--- a/locale/nl/LC_MESSAGES/django.po
+++ b/locale/nl/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-23 21:00+0000\n"
+"POT-Creation-Date: 2016-03-25 15:21+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -162,13 +162,6 @@ msgstr ""
 msgid "Manage push applications"
 msgstr ""
 
-#: push/templates/push/landing.html:16
-#, python-format
-msgid ""
-"<a href=\"%(href)s?next=%(request.path)s\">Sign in</a> to track your push "
-"applications "
-msgstr ""
-
 #: push/templates/push/list.html:20
 msgid "Domain"
 msgstr ""
@@ -260,14 +253,10 @@ msgstr ""
 msgid "404 Not Found"
 msgstr ""
 
-#. Translators: the <i></i> is a firefox icon in the middle of the phrase.
-#: templates/includes/fxa_sign_in_link.html:5
-#, python-format
-msgid ""
-"<a class=\"button sign-in-btn\" href=\"%(href)s?next=%(request.path)s\">Sign "
-"in with <i class=\"fa fa-firefox\"></i> Firefox Account</a>"
+#: templates/includes/fxa_sign_in_link.html:4
+msgid "Sign in with Firefox Account"
 msgstr ""
 
-#: templates/includes/fxa_sign_in_link.html:7
+#: templates/includes/fxa_sign_in_link.html:6
 msgid "Note: Using dev FxA Environment"
 msgstr ""

--- a/locale/pl/LC_MESSAGES/django.po
+++ b/locale/pl/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-23 21:00+0000\n"
+"POT-Creation-Date: 2016-03-25 15:21+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -163,13 +163,6 @@ msgstr ""
 msgid "Manage push applications"
 msgstr ""
 
-#: push/templates/push/landing.html:16
-#, python-format
-msgid ""
-"<a href=\"%(href)s?next=%(request.path)s\">Sign in</a> to track your push "
-"applications "
-msgstr ""
-
 #: push/templates/push/list.html:20
 msgid "Domain"
 msgstr ""
@@ -261,14 +254,10 @@ msgstr ""
 msgid "404 Not Found"
 msgstr ""
 
-#. Translators: the <i></i> is a firefox icon in the middle of the phrase.
-#: templates/includes/fxa_sign_in_link.html:5
-#, python-format
-msgid ""
-"<a class=\"button sign-in-btn\" href=\"%(href)s?next=%(request.path)s\">Sign "
-"in with <i class=\"fa fa-firefox\"></i> Firefox Account</a>"
+#: templates/includes/fxa_sign_in_link.html:4
+msgid "Sign in with Firefox Account"
 msgstr ""
 
-#: templates/includes/fxa_sign_in_link.html:7
+#: templates/includes/fxa_sign_in_link.html:6
 msgid "Note: Using dev FxA Environment"
 msgstr ""

--- a/locale/ru/LC_MESSAGES/django.po
+++ b/locale/ru/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-23 21:00+0000\n"
+"POT-Creation-Date: 2016-03-25 15:21+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,13 +164,6 @@ msgstr ""
 msgid "Manage push applications"
 msgstr ""
 
-#: push/templates/push/landing.html:16
-#, python-format
-msgid ""
-"<a href=\"%(href)s?next=%(request.path)s\">Sign in</a> to track your push "
-"applications "
-msgstr ""
-
 #: push/templates/push/list.html:20
 msgid "Domain"
 msgstr ""
@@ -262,14 +255,10 @@ msgstr ""
 msgid "404 Not Found"
 msgstr ""
 
-#. Translators: the <i></i> is a firefox icon in the middle of the phrase.
-#: templates/includes/fxa_sign_in_link.html:5
-#, python-format
-msgid ""
-"<a class=\"button sign-in-btn\" href=\"%(href)s?next=%(request.path)s\">Sign "
-"in with <i class=\"fa fa-firefox\"></i> Firefox Account</a>"
+#: templates/includes/fxa_sign_in_link.html:4
+msgid "Sign in with Firefox Account"
 msgstr ""
 
-#: templates/includes/fxa_sign_in_link.html:7
+#: templates/includes/fxa_sign_in_link.html:6
 msgid "Note: Using dev FxA Environment"
 msgstr ""

--- a/push/templates/push/landing.html
+++ b/push/templates/push/landing.html
@@ -13,7 +13,7 @@
         {% if request.user.is_authenticated %}
         <a class="button" href="{% url 'push.list' %}">{% trans "Manage push applications" %}</a>
         {% else %}
-        <p>{% blocktrans href=provider_login_url "fxa" %}<a href="{{ href }}?next={{ request.path }}">Sign in</a> to track your push applications{% endblocktrans %}</p>
+        {% include "includes/fxa_sign_in_link.html" %}
         {% endif %}
     </div>
 {% endblock %}

--- a/templates/includes/fxa_sign_in_link.html
+++ b/templates/includes/fxa_sign_in_link.html
@@ -1,8 +1,7 @@
 {% load i18n %}
 {% load socialaccount %}
 <div class="sign-in-area">
-    {% comment %}Translators: the <i></i> is a firefox icon in the middle of the phrase.{% endcomment %}
-    {% blocktrans href=provider_login_url "fxa"%}<a class="button sign-in-btn" href="{{ href }}?next={{ request.path }}">Sign in with <i class="fa fa-firefox"></i> Firefox Account</a>{% endblocktrans %}
+    <a class="button sign-in-btn" href="{% provider_login_url "fxa" %}"><i class="fa fa-firefox"></i>{% trans "Sign in with Firefox Account" %}</a>
     {% if 'dev.lcip.org' in settings.SOCIALACCOUNT_PROVIDERS.fxa.OAUTH_ENDPOINT %}
     <div class="callout warning sign-in-tooltip">{% trans "Note: Using dev FxA Environment" %}</div>
     {% endif %}


### PR DESCRIPTION
Including the `<i>` element in the `{% blocktrans %}` confuses translation. `{% provider_login_url %}` also does not work within a `{% blocktrans %}` template tag.

So, moving the `<i>` element to the front of the sign-in text to make everything easier.

Also, updating translation strings to match.
