### PR TITLE
add ga to style-src csp

### DIFF
--- a/dashboard/settings.py
+++ b/dashboard/settings.py
@@ -260,4 +260,4 @@ CSP_FONT_SRC = ('code.cdn.mozilla.net', 'maxcdn.bootstrapcdn.com')
 CSP_SCRIPT_SRC = ("'self'", 'cdn.jsdelivr.net', 'ajax.googleapis.com',
                   'www.google-analytics.com')
 CSP_STYLE_SRC = ("'self'", 'cdn.jsdelivr.net', 'code.cdn.mozilla.net',
-                 'maxcdn.bootstrapcdn.com')
+                 'maxcdn.bootstrapcdn.com', 'www.google-analytics.com')


### PR DESCRIPTION
GA needs to be in the `style-src` csp directive.
