### PR TITLE
176 healthcheck endpoints

### DIFF
--- a/.env
+++ b/.env
@@ -5,3 +5,5 @@ FXA_PROFILE_ENDPOINT=https://stable.dev.lcip.org/profile/v1/profile
 DNS_VALIDATION_SERVER=8.8.8.8
 PUSH_MESSAGES_API_ENDPOINT=https://szdqmc7xl7.execute-api.us-east-1.amazonaws.com/test/
 GOOGLE_ANALYTICS_ACCOUNT=
+HEALTHCHECK_URL=__heartbeat__
+LBHEALTHCHECK_URL=__lbheartbeat__

--- a/dashboard/settings.py
+++ b/dashboard/settings.py
@@ -32,6 +32,10 @@ DEBUG = config('DJANGO_DEBUG', default=False, cast=bool)
 ALLOWED_HOSTS = ['*']
 
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+SECURE_REDIRECT_EXEMPT = [
+    '^__heartbeat__$',
+    '^__lbheartbeat__$',
+]
 if DEBUG is False:
     CSRF_COOKIE_HTTPONLY = True
     CSRF_COOKIE_SECURE = True

--- a/dashboard/settings.py
+++ b/dashboard/settings.py
@@ -31,11 +31,19 @@ DEBUG = config('DJANGO_DEBUG', default=False, cast=bool)
 
 ALLOWED_HOSTS = ['*']
 
+ROOT_URLCONF = 'dashboard.urls'
+
+HEALTHCHECK_URL = '^%s$' % config('HEALTHCHECK_URL', default='__heartbeat__'),
+LBHEALTHCHECK_URL = '^%s$' % config(
+    'LBHEALTHCHECK_URL', default='__lbheartbeat__'
+)
+
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 SECURE_REDIRECT_EXEMPT = [
-    '^__heartbeat__$',
-    '^__lbheartbeat__$',
+    '^%s$' % HEALTHCHECK_URL,
+    '^%s$' % LBHEALTHCHECK_URL,
 ]
+
 if DEBUG is False:
     CSRF_COOKIE_HTTPONLY = True
     CSRF_COOKIE_SECURE = True
@@ -96,8 +104,6 @@ MIDDLEWARE_CLASSES = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'waffle.middleware.WaffleMiddleware',
 ]
-
-ROOT_URLCONF = 'dashboard.urls'
 
 TEMPLATES = [
     {

--- a/dashboard/tests.py
+++ b/dashboard/tests.py
@@ -37,6 +37,8 @@ class DashboardUrlTestsFor200(UrlTestsFor200):
     def setUp(self):
         super(DashboardUrlTestsFor200, self).setUp()
         self.signed_out_urls = (
+            '/__heartbeat__',
+            '/__lbheartbeat__',
             '/en/',
             '/accounts/login/',
         )

--- a/dashboard/urls.py
+++ b/dashboard/urls.py
@@ -24,8 +24,10 @@ handler500 = dashboard_views.InternalServerError.as_view()
 
 urlpatterns = [
     # dockerflow healthcheck endpoints
-    url(r'^__heartbeat__$', dashboard_views.Heartbeat.as_view(), name='heartbeat'),
-    url(r'^__lbheartbeat__$', dashboard_views.Heartbeat.as_view(), name='lbheartbeat'),
+    url(r'^__heartbeat__$',
+        dashboard_views.Heartbeat.as_view(), name='heartbeat'),
+    url(r'^__lbheartbeat__$',
+        dashboard_views.Heartbeat.as_view(), name='lbheartbeat'),
 
     # 3rd-party app urls
     url(r'^accounts/', include('allauth.urls')),

--- a/dashboard/urls.py
+++ b/dashboard/urls.py
@@ -13,6 +13,7 @@ Including another URLconf
     1. Import the include() function: from django.conf.urls import url, include
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
+from django.conf import settings
 from django.conf.urls import url, include
 from django.conf.urls.i18n import i18n_patterns
 from django.contrib import admin
@@ -24,9 +25,9 @@ handler500 = dashboard_views.InternalServerError.as_view()
 
 urlpatterns = [
     # dockerflow healthcheck endpoints
-    url(r'^__heartbeat__$',
+    url(r'^%s$' % settings.HEALTHCHECK_URL,
         dashboard_views.Heartbeat.as_view(), name='heartbeat'),
-    url(r'^__lbheartbeat__$',
+    url(r'^%s$' % settings.LBHEALTHCHECK_URL,
         dashboard_views.Heartbeat.as_view(), name='lbheartbeat'),
 
     # 3rd-party app urls

--- a/dashboard/urls.py
+++ b/dashboard/urls.py
@@ -23,6 +23,10 @@ handler403 = dashboard_views.PermissionDenied.as_view()
 handler500 = dashboard_views.InternalServerError.as_view()
 
 urlpatterns = [
+    # dockerflow healthcheck endpoints
+    url(r'^__heartbeat__$', dashboard_views.Heartbeat.as_view(), name='heartbeat'),
+    url(r'^__lbheartbeat__$', dashboard_views.Heartbeat.as_view(), name='lbheartbeat'),
+
     # 3rd-party app urls
     url(r'^accounts/', include('allauth.urls')),
     url(r'^api/docs/', include('rest_framework_swagger.urls')),

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -1,4 +1,5 @@
-from django.views.generic import TemplateView
+from django.http import HttpResponse
+from django.views.generic import TemplateView, View
 
 
 class Home(TemplateView):
@@ -15,3 +16,8 @@ class PermissionDenied(TemplateView):
 
 class InternalServerError(TemplateView):
     template_name = 'dashboard/errors/500.html'
+
+
+class Heartbeat(View):
+    def get(self, request, *args, **kwargs):
+        return HttpResponse('OK')


### PR DESCRIPTION
Superseding https://github.com/mozilla-services/push-dev-dashboard/pull/177 with code to pull the endpoint urls from `HEALTHCHECK_URL` environment variable - the Deis convention for kubernetes container probes.
