### PR TITLE
Fix the bug where not all characters got URL encoded

### DIFF
--- a/push/models.py
+++ b/push/models.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 from base64 import urlsafe_b64decode
+from urllib.parse import quote
 import json
 import uuid
 
@@ -201,6 +202,6 @@ class PushApplication(models.Model):
 def delete_key_from_messages_api(sender, instance, **kwargs):
     resp = push_messages_api_request(
         'delete',
-        '/keys/%s' % instance.vapid_key
+        '/keys/%s' % quote(instance.vapid_key, safe='')
     )
     return resp

--- a/push/models.py
+++ b/push/models.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from base64 import urlsafe_b64decode
-from urllib.parse import quote
+from urllib import quote
 import json
 import uuid
 


### PR DESCRIPTION
When calling the `delete_key_from_messages_api` with `instance.vapid_key` containing characters, such as "/" (forward slash), the request returns MessagesAPIError, as the vapid_key is parsed literally.

`quote(instance.vapid_key, safe='')` ensures the forward slash is not skipped in encoding.
